### PR TITLE
Custom provider

### DIFF
--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -23,6 +23,7 @@ export * from './deepseek/index.js';
 export * from './ollama/index.js';
 export * from './types.js';
 export * from './balance.js';
+export * from "./base.js"
 
 export type AIName =
   | 'openai'


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds an example on how to use a custom provider to README.md and it also exports the `BaseAI` class. 

- **What is the current behavior?** (You can also link to an open issue here)
`BaseAI` is not exported. This should close #11. 

- **What is the new behavior (if this is a feature change)?**
Exports the `BaseAI` class and the others exports found in [src/ai/base.ts](https://github.com/dosco/llm-client/blob/0dce59998bc731153a5d3588245e8fbfb7635727/src/ai/base.ts)
- **Other information**:
No