### PR TITLE
fix: Azure OpenAI chat/completion call failed (#19)

### DIFF
--- a/src/util/apicall.ts
+++ b/src/util/apicall.ts
@@ -27,7 +27,7 @@ export const apiCall = async <TRequest = unknown, TResponse = unknown>(
   json: TRequest
 ): Promise<TResponse | ReadableStream<TResponse>> => {
   const baseUrl = new URL(process.env.PROXY ?? api.url);
-  const apiPath = path.join(baseUrl.pathname, api.name ?? '/');
+  const apiPath = path.join(baseUrl.pathname, api.name ?? '/', baseUrl.search);
   const apiUrl = new URL(apiPath, baseUrl);
 
   if (api.span?.isRecording()) {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
issue: Azure OpenAI chat/completion call failed (#19 )

End point called: https://sqalia.openai.azure.com/openai/deployments/Sqalia4o/chat/completions/
(with an error 404 not found because api-version is required)

- **What is the new behavior (if this is a feature change)?**
End point called: https://sqalia.openai.azure.com/openai/deployments/Sqalia4o/chat/completions/?api-version=2024-02-01

- **Other information**:
The issue is from the apiCall function who forgets the search parameters from baseURL
