### PR TITLE
Updated Cohere, Groq, marketing.py

### DIFF
--- a/src/ai/cohere/api.ts
+++ b/src/ai/cohere/api.ts
@@ -220,6 +220,7 @@ export class Cohere extends BaseAI<
     const reqValue = {
       model,
       texts: req.texts ?? [],
+      input_type: 'classification',
       truncate: ''
     };
 

--- a/src/ai/groq/api.ts
+++ b/src/ai/groq/api.ts
@@ -11,7 +11,7 @@ type GroqAIConfig = OpenAIConfig;
  */
 export const GroqDefaultConfig = (): GroqAIConfig =>
   structuredClone({
-    model: 'llama2-70b-4096',
+    model: 'llama3-70b-8192',
     ...BaseAIDefaultConfig()
   });
 

--- a/src/examples/marketing.ts
+++ b/src/examples/marketing.ts
@@ -28,7 +28,7 @@ const res = await gen.forward({
   productDescription: product.description,
   toName: to.name,
   toDescription: to.title,
-  messageGuidelines: messageGuidelines
+  messageGuidelines: messageGuidelines.join(', ')
 });
 
 console.log('>', res);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Updated Cohere reqValue to include input_type (it's now required since v3). I included a default value of 'classification'. All values appear to work, but some might be better suited for certain use cases.
- Updated Groq model to llama3-70b-8192 (llama2-70b-4096 was depreciated)
- Added a temporary fix to the marketing.py example, since messageGuidelines expects a string, not a string array. (it's just a hack to get it working)

**What is the current behavior?** (You can also link to an open issue here)

- Cohere embeddings and Groq won't work without the updates.
- Marketing.py throws an error.
