### PR TITLE
fix: enable custom API URL configuration for OpenAI provider

### DIFF
--- a/src/ax/ai/integration.test.ts
+++ b/src/ax/ai/integration.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { ai } from './wrap.js';
+
+describe('AI Factory Integration', () => {
+  describe('OpenRouter and Custom API URL Support', () => {
+    it('should configure OpenRouter API URL correctly', () => {
+      const llm = ai({
+        name: 'openai',
+        apiKey: 'test-key',
+        apiURL: 'https://openrouter.ai/api/v1',
+      });
+
+      expect((llm as any).ai.apiURL).toBe('https://openrouter.ai/api/v1');
+    });
+
+    it('should configure custom OpenAI-compatible endpoints', () => {
+      const testCases = [
+        'https://custom-endpoint.com/v1',
+        'https://api.anthropic.com/v1',
+        'http://localhost:8080/v1',
+        'https://gateway.ai.cloudflare.com/v1',
+      ];
+
+      testCases.forEach((url) => {
+        const llm = ai({
+          name: 'openai',
+          apiKey: 'test-key',
+          apiURL: url,
+        });
+
+        expect((llm as any).ai.apiURL).toBe(url);
+      });
+    });
+
+    it('should use default OpenAI URL when apiURL is not specified', () => {
+      const llm = ai({
+        name: 'openai',
+        apiKey: 'test-key',
+      });
+
+      expect((llm as any).ai.apiURL).toBe('https://api.openai.com/v1');
+    });
+  });
+});

--- a/src/ax/ai/openai/api.test.ts
+++ b/src/ax/ai/openai/api.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { AxAIOpenAI } from './api.js';
+
+describe('AxAIOpenAI', () => {
+  describe('API URL configuration', () => {
+    it('should use default OpenAI API URL when apiURL is not provided', () => {
+      const llm = new AxAIOpenAI({
+        apiKey: 'test-key',
+      });
+
+      expect((llm as any).apiURL).toBe('https://api.openai.com/v1');
+    });
+
+    it('should use custom API URL when apiURL is provided', () => {
+      const customUrl = 'https://openrouter.ai/api/v1';
+      const llm = new AxAIOpenAI({
+        apiKey: 'test-key',
+        apiURL: customUrl,
+      });
+
+      expect((llm as any).apiURL).toBe(customUrl);
+    });
+
+    it('should use different custom API URL formats', () => {
+      const testCases = [
+        'https://custom-endpoint.com/v1',
+        'https://api.anthropic.com/v1',
+        'http://localhost:8080/v1',
+        'https://gateway.ai.cloudflare.com/v1',
+      ];
+
+      testCases.forEach((url) => {
+        const llm = new AxAIOpenAI({
+          apiKey: 'test-key',
+          apiURL: url,
+        });
+
+        expect((llm as any).apiURL).toBe(url);
+      });
+    });
+
+    it('should work with ai() factory function and custom API URL', () => {
+      // This test verifies the factory function properly passes apiURL
+      // We'll test this via the AxAIOpenAI constructor which is what the factory uses
+      const llm = new AxAIOpenAI({
+        apiKey: 'test-key',
+        apiURL: 'https://openrouter.ai/api/v1',
+      });
+
+      expect((llm as any).apiURL).toBe('https://openrouter.ai/api/v1');
+    });
+  });
+});

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -659,6 +659,7 @@ export class AxAIOpenAI<TModelKey = string> extends AxAIOpenAIBase<
 > {
   constructor({
     apiKey,
+    apiURL,
     config,
     options,
     models,
@@ -741,6 +742,7 @@ export class AxAIOpenAI<TModelKey = string> extends AxAIOpenAIBase<
 
     super({
       apiKey,
+      apiURL,
       config: {
         ...axAIOpenAIDefaultConfig(),
         ...config,


### PR DESCRIPTION
## Summary
- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
  The `apiURL` parameter is not properly passed to the OpenAI provider, causing requests to always go to `api.openai.com` regardless of the configured URL. This prevents usage with OpenRouter and other OpenAI-compatible endpoints. Fixes #297.

- **What is the new behavior (if this is a feature change)?**
  The `apiURL` parameter is now properly destructured and passed to the parent constructor, allowing users to configure custom OpenAI-compatible endpoints like OpenRouter.

- **Other information**:
  - Added comprehensive test coverage to prevent regression
  - Tests verify both direct constructor usage and factory function usage
  - Supports any OpenAI-compatible endpoint URL

## Test plan
- [x] Added unit tests for `AxAIOpenAI` class API URL configuration
- [x] Added integration tests for `ai()` factory function
- [x] Verified custom API URLs work correctly (OpenRouter, localhost, custom endpoints)
- [x] Verified default OpenAI URL behavior remains unchanged
- [x] All tests pass