### PR TITLE
fix: resolve duplicate AxMultiMetricFn type declaration

### DIFF
--- a/src/ax/dsp/common_types.ts
+++ b/src/ax/dsp/common_types.ts
@@ -16,7 +16,7 @@ export type AxMetricFnArgs = Parameters<AxMetricFn>[0];
 
 export type AxMultiMetricFn = <T = any>(
   arg0: Readonly<{ prediction: T; example: AxExample }>
-) => Record<string, number>;
+) => Record<string, number> | Promise<Record<string, number>>;
 
 export interface AxOptimizationProgress {
   round: number;

--- a/src/ax/dsp/optimizer.ts
+++ b/src/ax/dsp/optimizer.ts
@@ -30,13 +30,9 @@ import type { AxGenOut, AxProgramDemos } from './types.js';
 
 // Logger utilities are now exported from ./loggers.js
 
-// Multi-objective metric function for Pareto optimization
-export type AxMultiMetricFn = <T = any>(
-  arg0: Readonly<{ prediction: T; example: AxExample }>
-) => Record<string, number> | Promise<Record<string, number>>;
+// Multi-objective metric function for Pareto optimization is now defined in common_types.ts
 
 // Common types moved to ./common_types.ts
-
 
 // Progress tracking interface for real-time updates
 // AxOptimizationProgress moved to ./common_types.ts


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
TypeScript compilation fails with error TS2440: Import declaration conflicts with local declaration of 'AxMultiMetricFn' in optimizer.ts

## What is the new behavior?
- Updated AxMultiMetricFn type in common_types.ts to support Promise returns
- Removed duplicate local declaration in optimizer.ts
- TypeScript compilation now passes successfully

## Other information:
This fix resolves a duplicate type declaration issue that was causing npm ci to fail during the prepare script. The AxMultiMetricFn type was defined both as an import from common_types.ts and as a local declaration in optimizer.ts, causing a conflict.