### PR TITLE
feat: add GPT-4.1 nano model support

### DIFF
--- a/src/ax/ai/openai/chat_types.ts
+++ b/src/ax/ai/openai/chat_types.ts
@@ -5,6 +5,7 @@ export enum AxAIOpenAIModel {
   GPT4 = 'gpt-4',
   GPT41 = 'gpt-4.1',
   GPT41Mini = 'gpt-4.1-mini',
+  GPT41Nano = 'gpt-4.1-nano',
   GPT4O = 'gpt-4o',
   GPT4OMini = 'gpt-4o-mini',
   GPT4ChatGPT4O = 'chatgpt-4o-latest',

--- a/src/ax/ai/openai/info.ts
+++ b/src/ax/ai/openai/info.ts
@@ -27,6 +27,12 @@ export const axModelInfoOpenAI: AxModelInfo[] = [
     completionTokenCostPer1M: 1.6,
   },
   {
+    name: AxAIOpenAIModel.GPT41Nano,
+    currency: 'usd',
+    promptTokenCostPer1M: 0.1,
+    completionTokenCostPer1M: 0.4,
+  },
+  {
     name: AxAIOpenAIModel.GPT4O,
     currency: 'usd',
     promptTokenCostPer1M: 5,
@@ -160,6 +166,12 @@ export const axModelInfoOpenAIResponses: AxModelInfo[] = [
     currency: 'usd',
     promptTokenCostPer1M: 0.4,
     completionTokenCostPer1M: 1.6,
+  },
+  {
+    name: AxAIOpenAIResponsesModel.GPT41Nano,
+    currency: 'usd',
+    promptTokenCostPer1M: 0.1,
+    completionTokenCostPer1M: 0.4,
   },
   {
     name: AxAIOpenAIResponsesModel.GPT4O,

--- a/src/ax/ai/openai/responses_types.ts
+++ b/src/ax/ai/openai/responses_types.ts
@@ -10,6 +10,7 @@ export enum AxAIOpenAIResponsesModel {
   GPT4 = 'gpt-4',
   GPT41 = 'gpt-4.1',
   GPT41Mini = 'gpt-4.1-mini',
+  GPT41Nano = 'gpt-4.1-nano',
   GPT4O = 'gpt-4o',
   GPT4OMini = 'gpt-4o-mini',
   GPT4ChatGPT4O = 'chatgpt-4o-latest',


### PR DESCRIPTION
  - **What kind of change does this PR introduce?**
  Feature - Add support for GPT-4.1 nano model

  - **What is the current behavior?**
  The codebase currently supports GPT-4.1 and GPT-4.1 mini models, but does not include the GPT-4.1 nano model which is the fastest and most cost-efficient version of
   GPT-4.1.

  - **What is the new behavior (if this is a feature change)?**
  This PR adds full support for the GPT-4.1 nano model (`gpt-4.1-nano`) across both Chat Completions and Responses APIs with:
  - Model enum definition in `AxAIOpenAIModel` and `AxAIOpenAIResponsesModel`
  - Pricing configuration: $0.10 per 1M input tokens, $0.40 per 1M output tokens
  - 1,047,576 token context window
  - 32,768 max output tokens
  - Support for text and image input, streaming, function calling, structured outputs, and predicted outputs

  The model is positioned after GPT-4.1 mini in the model hierarchy, following the pattern: GPT-4.1 → GPT-4.1 mini → GPT-4.1 nano

  - **Other information**:
  Pricing and specifications are based on the official OpenAI documentation for GPT-4.1 nano. This model is ideal for high-volume, latency-sensitive applications that
   require fast inference at minimal cost.