### PR TITLE
Add support for caching the system prompt in Anthropic models

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -210,7 +210,7 @@ class AxAIAnthropicImpl
       .map((msg) => ({
         type: 'text' as const,
         text: msg.content,
-        ...(msg.cache ? { cache: { type: 'ephemeral' } } : {}),
+        ...(msg.cache ? { cache_control: { type: 'ephemeral' as const } } : {}),
       }));
 
     const otherMessages = req.chatPrompt.filter((msg) => msg.role !== 'system');
@@ -472,6 +472,8 @@ class AxAIAnthropicImpl
       promptTokens: resp.usage.input_tokens,
       completionTokens: resp.usage.output_tokens,
       totalTokens: resp.usage.input_tokens + resp.usage.output_tokens,
+      cacheCreationTokens: resp.usage.cache_creation_input_tokens,
+      cacheReadTokens: resp.usage.cache_read_input_tokens,
     };
 
     return { results, remoteId: resp.id };

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -195,6 +195,8 @@ export type AxAIAnthropicChatResponse = {
   usage: {
     input_tokens: number;
     output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
   };
 };
 

--- a/src/ax/dsp/generate.ts
+++ b/src/ax/dsp/generate.ts
@@ -152,6 +152,7 @@ export class AxGen<IN = any, OUT extends AxGenOut = any>
     const promptTemplateOptions = {
       functions: options?.functions,
       thoughtFieldName: this.thoughtFieldName,
+      cacheSystemPrompt: options?.cacheSystemPrompt,
     };
     this.promptTemplate = new (options?.promptTemplate ?? AxPromptTemplate)(
       this.signature,
@@ -508,6 +509,9 @@ export class AxGen<IN = any, OUT extends AxGenOut = any>
     const functionCallMode =
       options.functionCallMode ?? this.options?.functionCallMode ?? 'auto';
 
+    const cacheSystemPrompt =
+      options.cacheSystemPrompt ?? this.options?.cacheSystemPrompt;
+
     // Handle prompt mode
     if (hasFunctions && functionCallMode === 'prompt') {
       this.signatureToolCallingManager = new SignatureToolCallingManager(
@@ -543,6 +547,7 @@ export class AxGen<IN = any, OUT extends AxGenOut = any>
       // Prefer per-call functions; fall back to parsed functions from constructor
       functions: this.signatureToolCallingManager ? [] : functions,
       thoughtFieldName: this.thoughtFieldName,
+      cacheSystemPrompt,
     };
 
     this.promptTemplate = new promptTemplateClass(

--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -12,6 +12,7 @@ type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 export interface AxPromptTemplateOptions {
   functions?: Readonly<AxInputFunctionType>;
   thoughtFieldName?: string;
+  cacheSystemPrompt?: boolean;
 }
 type AxChatRequestChatPrompt = Writeable<AxChatRequest['chatPrompt'][0]>;
 
@@ -46,6 +47,7 @@ export class AxPromptTemplate {
   private task: { type: 'text'; text: string };
   private readonly thoughtFieldName: string;
   private readonly functions?: Readonly<AxInputFunctionType>;
+  private readonly cacheSystemPrompt?: boolean;
 
   constructor(
     sig: Readonly<AxSignature>,
@@ -56,6 +58,7 @@ export class AxPromptTemplate {
     this.fieldTemplates = fieldTemplates;
     this.thoughtFieldName = options?.thoughtFieldName ?? 'thought';
     this.functions = options?.functions;
+    this.cacheSystemPrompt = options?.cacheSystemPrompt;
 
     const task = [];
 
@@ -166,6 +169,7 @@ export class AxPromptTemplate {
     const systemPrompt = {
       role: 'system' as const,
       content: systemContent,
+      cache: this.cacheSystemPrompt,
     };
 
     if (Array.isArray(values)) {

--- a/src/ax/dsp/types.ts
+++ b/src/ax/dsp/types.ts
@@ -106,6 +106,8 @@ export type AxProgramForwardOptions<MODEL> = AxAIServiceOptions & {
   fastFail?: boolean;
   showThoughts?: boolean;
   functionCallMode?: 'auto' | 'native' | 'prompt';
+  cacheSystemPrompt?: boolean;
+
   // Memory tag cleanup control
   disableMemoryCleanup?: boolean;
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature + Bug fix

- **What is the current behavior?** (You can also link to an open issue here)
Currently the prompt cache is never used:

```
[ CHAT RESPONSE USAGE ]
AI: Anthropic
Model: claude-haiku-4-5-20251001
Total Tokens: 6790
Prompt Tokens: 6747
Completion Tokens: 43
Cache Creation Tokens: 0  <--
Cache Read Tokens: 0      <--
```

- **What is the new behavior (if this is a feature change)?**
Prompt caching for the system prompt can be optionally enabled either at the AxGen for Forward levels, e.g.:

```typescript
const { summary } = await gen.forward(
  ai,
  { content },
  { cacheSystemPrompt: true },
);
```

On the first request, the cache is created:

```
[ CHAT RESPONSE USAGE ]
AI: Anthropic
Model: claude-haiku-4-5-20251001
Total Tokens: 65
Prompt Tokens: 22
Completion Tokens: 43
Cache Creation Tokens: 6727  <--
Cache Read Tokens: 0
```

Subsequent requests read from the cache:

```
[ CHAT RESPONSE USAGE ]
AI: Anthropic
Model: claude-haiku-4-5-20251001
Total Tokens: 65
Prompt Tokens: 22
Completion Tokens: 43
Cache Creation Tokens: 0
Cache Read Tokens: 6725  <--
```

Also hooked it up to show cache usage in the "token usage" debug section, as shown above.

