### PR TITLE
fix(google-gemini): align Google Maps grounding types/options and retrievalConfig with Gemini API shape

### DIFF
--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -32,6 +32,8 @@ import {
   type AxAIGoogleGeminiContentPart,
   AxAIGoogleGeminiEmbedModel,
   type AxAIGoogleGeminiGenerationConfig,
+  type AxAIGoogleGeminiToolGoogleMaps,
+  type AxAIGoogleGeminiRetrievalConfig,
   AxAIGoogleGeminiModel,
   AxAIGoogleGeminiSafetyCategory,
   type AxAIGoogleGeminiSafetySettings,
@@ -138,11 +140,8 @@ export interface AxAIGoogleGeminiOptionsTools {
   };
   googleSearch?: boolean;
   urlContext?: boolean;
-  googleMaps?: boolean;
-  googleMapsRetrieval?: {
-    latLng?: { latitude: number; longitude: number };
-    enableWidget?: boolean;
-  };
+  googleMaps?: AxAIGoogleGeminiToolGoogleMaps;
+  retrievalConfig?: AxAIGoogleGeminiRetrievalConfig;
 }
 
 export interface AxAIGoogleGeminiArgs<TModelKey> {
@@ -396,10 +395,9 @@ class AxAIGoogleGeminiImpl
     }
 
     if (this.options?.googleMaps) {
+      const gm = this.options.googleMaps;
       const mapsToolCfg =
-        this.options.googleMapsRetrieval?.enableWidget !== undefined
-          ? { enable_widget: this.options.googleMapsRetrieval.enableWidget }
-          : {};
+        gm?.enableWidget !== undefined ? { enableWidget: gm.enableWidget } : {};
       tools.push({ google_maps: mapsToolCfg } as any);
     }
 
@@ -461,13 +459,13 @@ class AxAIGoogleGeminiImpl
       } as any;
     }
 
-    // Merge Maps retrieval_config if provided (snake_case to follow request shape)
-    if (this.options?.googleMapsRetrieval) {
+    // Merge retrievalConfig if provided
+    if (this.options?.retrievalConfig) {
       toolConfig = {
         ...(toolConfig ?? {}),
-        retrieval_config: {
-          ...(this.options.googleMapsRetrieval.latLng
-            ? { lat_lng: this.options.googleMapsRetrieval.latLng }
+        retrievalConfig: {
+          ...(this.options.retrievalConfig.latLng
+            ? { latLng: this.options.retrievalConfig.latLng }
             : {}),
         },
       } as any;

--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -101,14 +101,8 @@ export type AxAIGoogleGeminiToolGoogleSearchRetrieval = {
   };
 };
 
-export type AxAIGoogleGeminiToolGoogleMapsRetrieval = {
-  retrieval_config: {
-    lat_lng?: { latitude: number; longitude: number };
-  };
-};
-
 export type AxAIGoogleGeminiToolGoogleMaps = {
-  enable_widget?: boolean;
+  enableWidget?: boolean;
 };
 
 export type AxAIGoogleGeminiTool = {
@@ -118,7 +112,6 @@ export type AxAIGoogleGeminiTool = {
   google_search?: object;
   url_context?: object;
   google_maps?: AxAIGoogleGeminiToolGoogleMaps;
-  google_maps_retrieval?: AxAIGoogleGeminiToolGoogleMapsRetrieval;
 };
 
 export type AxAIGoogleGeminiToolConfig = {
@@ -126,10 +119,7 @@ export type AxAIGoogleGeminiToolConfig = {
     mode: 'ANY' | 'NONE' | 'AUTO';
     allowed_function_names?: string[];
   };
-  retrieval_config?: {
-    lat_lng?: { latitude: number; longitude: number };
-    enable_widget?: boolean;
-  };
+  retrievalConfig?: AxAIGoogleGeminiRetrievalConfig;
 };
 
 export type AxAIGoogleGeminiGenerationConfig = {
@@ -145,6 +135,10 @@ export type AxAIGoogleGeminiGenerationConfig = {
     thinkingBudget?: number;
     includeThoughts?: boolean;
   };
+};
+
+export type AxAIGoogleGeminiRetrievalConfig = {
+  latLng?: { latitude: number; longitude: number };
 };
 
 export type AxAIGoogleGeminiSafetySettings = {

--- a/src/ax/index.ts
+++ b/src/ax/index.ts
@@ -105,6 +105,7 @@ import {
   AxAIGoogleGeminiEmbedTypes,
   type AxAIGoogleGeminiGenerationConfig,
   AxAIGoogleGeminiModel,
+  type AxAIGoogleGeminiRetrievalConfig,
   AxAIGoogleGeminiSafetyCategory,
   type AxAIGoogleGeminiSafetySettings,
   AxAIGoogleGeminiSafetyThreshold,
@@ -114,7 +115,6 @@ import {
   type AxAIGoogleGeminiToolConfig,
   type AxAIGoogleGeminiToolFunctionDeclaration,
   type AxAIGoogleGeminiToolGoogleMaps,
-  type AxAIGoogleGeminiToolGoogleMapsRetrieval,
   type AxAIGoogleGeminiToolGoogleSearchRetrieval,
   type AxAIGoogleVertexBatchEmbedRequest,
   type AxAIGoogleVertexBatchEmbedResponse,
@@ -944,6 +944,7 @@ export type { AxAIGoogleGeminiContent };
 export type { AxAIGoogleGeminiContentPart };
 export type { AxAIGoogleGeminiGenerationConfig };
 export type { AxAIGoogleGeminiOptionsTools };
+export type { AxAIGoogleGeminiRetrievalConfig };
 export type { AxAIGoogleGeminiSafetySettings };
 export type { AxAIGoogleGeminiThinkingConfig };
 export type { AxAIGoogleGeminiThinkingTokenBudgetLevels };
@@ -951,7 +952,6 @@ export type { AxAIGoogleGeminiTool };
 export type { AxAIGoogleGeminiToolConfig };
 export type { AxAIGoogleGeminiToolFunctionDeclaration };
 export type { AxAIGoogleGeminiToolGoogleMaps };
-export type { AxAIGoogleGeminiToolGoogleMapsRetrieval };
 export type { AxAIGoogleGeminiToolGoogleSearchRetrieval };
 export type { AxAIGoogleVertexBatchEmbedRequest };
 export type { AxAIGoogleVertexBatchEmbedResponse };

--- a/src/examples/gemini-google-maps.ts
+++ b/src/examples/gemini-google-maps.ts
@@ -11,10 +11,9 @@ const llm = ai({
   apiKey: process.env.GOOGLE_APIKEY!,
   model: AxAIGoogleGeminiModel.Gemini25FlashLite,
   options: {
-    googleMaps: true,
-    googleMapsRetrieval: {
+    googleMaps: { enableWidget: true },
+    retrievalConfig: {
       latLng: { latitude: 34.050481, longitude: -118.248526 },
-      enableWidget: true,
     },
   },
 });
@@ -25,3 +24,7 @@ const res = await mapsDemo.forward(llm, {
 });
 
 console.log(res.responseText);
+
+// Optional: print contextual widget token if returned
+const token = (res as any).providerMetadata?.google?.mapsWidgetContextToken;
+if (token) console.log('mapsWidgetContextToken:', token);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor fix. The shape of AxAIGoogleGeminiOptionsTools wasnt aligned with the official Gemini API. Changes include:
  - Matched case
  - A new named type `AxAIGoogleGeminiRetrievalConfig` aligned with Gemini API's centralized retrivalConfig
  - Update to interface AxAIGoogleGeminiTool

- **What is the current behavior?** (You can also link to an open issue here)
No change to behaviour, but better maintainability going forward.

- **What is the new behavior (if this is a feature change)?**

- **Other information**:
