### PR TITLE
feat: add AWS Bedrock provider integration

### DIFF
--- a/src/ax-ai-aws-bedrock/.npmignore
+++ b/src/ax-ai-aws-bedrock/.npmignore
@@ -1,0 +1,8 @@
+*.test.ts
+*.test-d.ts
+tsconfig.json
+tsup.config.ts
+.gitignore
+.npmignore
+src/
+

--- a/src/ax-ai-aws-bedrock/.prettierignore
+++ b/src/ax-ai-aws-bedrock/.prettierignore
@@ -1,0 +1,23 @@
+# Package files are formatted by package managers
+package.json
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+
+# Build outputs and distributions
+dist
+build
+
+# Generated indexes
+index.ts
+
+# Dependencies
+node_modules
+.pnpm-store
+
+# Documentation
+docs
+
+# Cache directories
+.cache
+.temp

--- a/src/ax-ai-aws-bedrock/README.md
+++ b/src/ax-ai-aws-bedrock/README.md
@@ -1,0 +1,77 @@
+# AWS Bedrock Provider for AX
+
+Production-ready AWS Bedrock integration for AX library. Supports Claude, GPT OSS, and Titan Embed models.
+
+## Features
+
+- **Claude models**: Sonnet 3.5, 3.7, 4.0
+- **GPT OSS models**: 120B, 20B
+- **Embeddings**: Titan Embed V2
+- Regional failover (separate configs for Claude and GPT)
+- Token usage tracking
+- Works with AX signatures, flows, and optimizers
+
+## Installation
+
+```bash
+npm install @ax-llm/ax-ai-aws-bedrock @ax-llm/ax @aws-sdk/client-bedrock-runtime
+```
+
+## Quick Start
+
+```typescript
+import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
+
+const ai = new AxAIBedrock({
+  region: 'us-east-2',
+  fallbackRegions: ['us-west-2', 'us-east-1'],
+  config: {
+    model: AxAIBedrockModel.ClaudeSonnet4,
+    temperature: 0.7,
+    maxTokens: 4096,
+  },
+});
+
+const response = await ai.chat({
+  chatPrompt: [
+    { role: 'system', content: 'You are a helpful assistant.' },
+    { role: 'user', content: 'What is AWS Bedrock?' },
+  ],
+});
+```
+
+## With AX Signatures
+
+```typescript
+import { AxSignature, AxGen } from '@ax-llm/ax';
+
+const ai = new AxAIBedrock({ config: { model: AxAIBedrockModel.ClaudeSonnet4 } });
+const summarize = new AxSignature('document: string -> summary: string');
+const program = new AxGen(summarize, { ai });
+
+const result = await program.forward({ document: 'Your text...' });
+```
+
+## Available Models
+
+```typescript
+// Claude
+AxAIBedrockModel.ClaudeSonnet4; // us.anthropic.claude-sonnet-4-20250514-v1:0
+AxAIBedrockModel.Claude37Sonnet; // anthropic.claude-3-7-sonnet-20250219-v1:0
+AxAIBedrockModel.Claude35Sonnet; // anthropic.claude-3-5-sonnet-20240620-v1:0
+
+// GPT OSS
+AxAIBedrockModel.GptOss120B; // openai.gpt-oss-120b-1:0
+AxAIBedrockModel.GptOss20B; // openai.gpt-oss-20b-1:0
+
+// Embeddings
+AxAIBedrockEmbedModel.TitanEmbedV2; // amazon.titan-embed-text-v2:0
+```
+
+## Testing
+
+```bash
+bun test packages/api/src/agent/ax-main/src/ax/ai/bedrock/api.test.ts
+```
+
+See `examples.ts` and `QUICKSTART.md` for more examples.

--- a/src/ax-ai-aws-bedrock/api.ts
+++ b/src/ax-ai-aws-bedrock/api.ts
@@ -1,0 +1,521 @@
+/**
+ * AWS Bedrock Provider for AX Library
+ * 
+ * Supports Claude, GPT OSS, and Titan Embed models for use with AX's
+ * compiler, signatures, flows, and optimization features.
+ * 
+ * Usage:
+ *   const ai = new AxAIBedrock({
+ *     region: 'us-east-2',
+ *     config: { model: AxAIBedrockModel.ClaudeSonnet4 }
+ *   });
+ * 
+ *   const sig = new AxSignature('input -> output');
+ *   const gen = new AxGen(sig, { ai });
+ *   const result = await gen.forward({ input: 'test' });
+ */
+
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+import type {
+    AxAIServiceImpl,
+    AxAIServiceOptions,
+    AxAPI,
+    AxChatResponse,
+    AxChatResponseResult,
+    AxEmbedResponse,
+    AxInternalChatRequest,
+    AxInternalEmbedRequest,
+    AxModelConfig,
+    AxTokenUsage,
+} from '@ax-llm/ax';
+import { AxBaseAI, axBaseAIDefaultConfig, type AxAIFeatures } from '@ax-llm/ax';
+import { axModelInfoBedrock } from './info.js';
+import {
+    AxAIBedrockEmbedModel,
+    AxAIBedrockModel,
+    type AxAIBedrockConfig,
+    type BedrockChatRequest,
+    type BedrockChatResponse,
+    type BedrockClaudeRequest,
+    type BedrockClaudeResponse,
+    type BedrockGptRequest,
+    type BedrockGptResponse,
+    type BedrockTitanEmbedRequest,
+    type BedrockTitanEmbedResponse,
+} from './types.js';
+
+// ============================================================================
+// IMPLEMENTATION - Converts between AX format and Bedrock format
+// ============================================================================
+
+type ModelFamily = 'claude' | 'gpt' | 'titan';
+
+class AxAIBedrockImpl
+    implements
+    AxAIServiceImpl<
+        AxAIBedrockModel,
+        AxAIBedrockEmbedModel,
+        BedrockChatRequest,
+        BedrockTitanEmbedRequest,
+        BedrockChatResponse,
+        never, // No streaming for now
+        BedrockTitanEmbedResponse
+    > {
+    private clients: Map<string, BedrockRuntimeClient> = new Map();
+    private tokensUsed?: AxTokenUsage;
+
+    constructor(
+        private config: AxAIBedrockConfig,
+        private primaryRegion: string,
+        private fallbackRegions: string[],
+        private gptRegion: string,
+        private gptFallbackRegions: string[],
+    ) { }
+
+    getTokenUsage(): AxTokenUsage | undefined {
+        return this.tokensUsed;
+    }
+
+    getModelConfig(): AxModelConfig {
+        return {
+            maxTokens: this.config.maxTokens,
+            temperature: this.config.temperature,
+            topP: this.config.topP,
+            stopSequences: this.config.stopSequences,
+        };
+    }
+
+    private getClient(region: string): BedrockRuntimeClient {
+        let client = this.clients.get(region);
+        if (!client) {
+            client = new BedrockRuntimeClient({ region });
+            this.clients.set(region, client);
+        }
+        return client;
+    }
+
+    /**
+     * Detect model family from model ID
+     */
+    private getModelFamily(modelId: string): ModelFamily {
+        if (modelId.includes('anthropic.claude') || modelId.includes('us.anthropic.claude')) {
+            return 'claude';
+        }
+        if (modelId.includes('openai.gpt')) {
+            return 'gpt';
+        }
+        if (modelId.includes('amazon.titan-embed')) {
+            return 'titan';
+        }
+        throw new Error(`Unknown model family for: ${modelId}`);
+    }
+
+    /**
+     * Get appropriate regions for model
+     */
+    private getRegionsForModel(modelId: string): string[] {
+        const family = this.getModelFamily(modelId);
+        if (family === 'gpt') {
+            return [this.gptRegion, ...this.gptFallbackRegions];
+        }
+        return [this.primaryRegion, ...this.fallbackRegions];
+    }
+
+    /**
+     * Regional failover logic - tries primary region, then fallbacks
+     */
+    private async invokeWithFailover<T>(
+        modelId: string,
+        handler: (client: BedrockRuntimeClient) => Promise<T>,
+    ): Promise<T> {
+        const regions = this.getRegionsForModel(modelId);
+        let lastError: Error | undefined;
+
+        for (const region of regions) {
+            try {
+                const client = this.getClient(region);
+                return await handler(client);
+            } catch (error) {
+                lastError = error as Error;
+                console.warn(`[Bedrock] Region ${region} failed for ${modelId}:`, error);
+            }
+        }
+
+        throw lastError || new Error(`All Bedrock regions failed for ${modelId}`);
+    }
+
+    /**
+     * Transform AX chat request → Bedrock request (Claude or GPT)
+     */
+    createChatReq = async (
+        req: Readonly<AxInternalChatRequest<AxAIBedrockModel>>,
+        config: Readonly<AxAIServiceOptions>,
+    ): Promise<[AxAPI, BedrockChatRequest]> => {
+        const family = this.getModelFamily(req.model);
+        const maxTokens = req.modelConfig?.maxTokens ?? this.config.maxTokens ?? 4096;
+        const temperature = req.modelConfig?.temperature ?? this.config.temperature;
+        const topP = req.modelConfig?.topP ?? this.config.topP;
+
+        let bedrockRequest: BedrockChatRequest;
+
+        if (family === 'claude') {
+            // Extract system messages for Claude
+            const systemMessages = req.chatPrompt
+                .filter((msg) => msg.role === 'system')
+                .map((msg) => msg.content)
+                .join('\n\n');
+
+            // Convert other messages to Claude format
+            const messages = req.chatPrompt
+                .filter((msg) => msg.role !== 'system')
+                .map((msg) => {
+                    if (msg.role === 'user') {
+                        return {
+                            role: 'user' as const,
+                            content: typeof msg.content === 'string'
+                                ? msg.content
+                                : JSON.stringify(msg.content),
+                        };
+                    }
+                    if (msg.role === 'assistant') {
+                        return {
+                            role: 'assistant' as const,
+                            content: msg.content || '',
+                        };
+                    }
+                    throw new Error(`Unsupported role: ${msg.role}`);
+                });
+
+            bedrockRequest = {
+                anthropic_version: 'bedrock-2023-05-31',
+                max_tokens: maxTokens,
+                messages,
+                ...(systemMessages ? { system: systemMessages } : {}),
+                ...(temperature !== undefined ? { temperature } : {}),
+                ...(topP !== undefined ? { top_p: topP } : {}),
+            } as BedrockClaudeRequest;
+        } else if (family === 'gpt') {
+            // GPT uses OpenAI-style format with system messages in array
+            const messages = req.chatPrompt
+                .filter((msg) => msg.role !== 'function') // Skip function messages
+                .map((msg) => {
+                    // Get content based on role
+                    let content: string;
+                    if ('content' in msg) {
+                        content = typeof msg.content === 'string'
+                            ? msg.content
+                            : JSON.stringify(msg.content);
+                    } else {
+                        content = '';
+                    }
+
+                    return {
+                        role: msg.role as 'system' | 'user' | 'assistant',
+                        content,
+                    };
+                });
+
+            bedrockRequest = {
+                messages,
+                max_tokens: maxTokens,
+                ...(temperature !== undefined ? { temperature } : {}),
+                ...(topP !== undefined ? { top_p: topP } : {}),
+            } as BedrockGptRequest;
+        } else {
+            throw new Error(`Chat not supported for model family: ${family}`);
+        }
+
+        // Create API config with local call (uses SDK instead of HTTP)
+        const apiConfig: AxAPI = {
+            name: `bedrock-${family}`,
+            localCall: async <TRequest, TResponse>(data: TRequest) => {
+                const reqBody = data as unknown as BedrockChatRequest;
+                const result = await this.invokeWithFailover(req.model, async (client) => {
+                    const command = new InvokeModelCommand({
+                        modelId: req.model,
+                        body: JSON.stringify(reqBody),
+                        contentType: 'application/json',
+                        accept: 'application/json',
+                    });
+                    const response = await client.send(command);
+                    return JSON.parse(new TextDecoder().decode(response.body));
+                });
+                return result as TResponse;
+            },
+        };
+
+        return [apiConfig, bedrockRequest];
+    };
+
+    /**
+     * Transform Bedrock response → AX chat response (Claude or GPT)
+     */
+    createChatResp(resp: Readonly<BedrockChatResponse>): AxChatResponse {
+        // Detect response type
+        if ('content' in resp && Array.isArray(resp.content)) {
+            // Claude response
+            return this.createClaudeChatResp(resp as BedrockClaudeResponse);
+        } else if ('choices' in resp && Array.isArray(resp.choices)) {
+            // GPT response
+            return this.createGptChatResp(resp as BedrockGptResponse);
+        }
+        throw new Error('Unknown response format');
+    }
+
+    /**
+     * Handle Claude-specific response format
+     */
+    private createClaudeChatResp(resp: Readonly<BedrockClaudeResponse>): AxChatResponse {
+        // Extract text content from response
+        let content = '';
+        for (const block of resp.content) {
+            if (block.type === 'text') {
+                content += block.text;
+            }
+        }
+
+        // Track token usage for AX's optimizer
+        this.tokensUsed = {
+            promptTokens: resp.usage.input_tokens,
+            completionTokens: resp.usage.output_tokens,
+            totalTokens: resp.usage.input_tokens + resp.usage.output_tokens,
+        };
+
+        // Map finish reason
+        let finishReason: AxChatResponseResult['finishReason'];
+        switch (resp.stop_reason) {
+            case 'end_turn':
+            case 'stop_sequence':
+                finishReason = 'stop';
+                break;
+            case 'max_tokens':
+                finishReason = 'length';
+                break;
+            default:
+                finishReason = undefined;
+        }
+
+        return {
+            results: [
+                {
+                    index: 0,
+                    id: resp.id,
+                    content,
+                    finishReason,
+                },
+            ],
+            remoteId: resp.id,
+        };
+    }
+
+    /**
+     * Handle GPT-specific response format
+     */
+    private createGptChatResp(resp: Readonly<BedrockGptResponse>): AxChatResponse {
+        const choice = resp.choices[0];
+        if (!choice) {
+            throw new Error('No choices in GPT response');
+        }
+
+        // Extract content (can be string or array)
+        let content = '';
+        if (typeof choice.message.content === 'string') {
+            content = choice.message.content;
+        } else if (Array.isArray(choice.message.content)) {
+            content = choice.message.content
+                .map((part) => {
+                    if (typeof part === 'string') return part;
+                    return part.text || part.content || '';
+                })
+                .join('');
+        }
+
+        // Track token usage if available
+        if (resp.usage) {
+            this.tokensUsed = {
+                promptTokens: resp.usage.prompt_tokens,
+                completionTokens: resp.usage.completion_tokens,
+                totalTokens: resp.usage.total_tokens,
+            };
+        }
+
+        // Map finish reason
+        let finishReason: AxChatResponseResult['finishReason'];
+        switch (choice.finish_reason) {
+            case 'stop':
+                finishReason = 'stop';
+                break;
+            case 'length':
+                finishReason = 'length';
+                break;
+            case 'content_filter':
+                finishReason = 'content_filter';
+                break;
+            default:
+                finishReason = undefined;
+        }
+
+        return {
+            results: [
+                {
+                    index: choice.index,
+                    id: resp.id,
+                    content,
+                    finishReason,
+                },
+            ],
+            remoteId: resp.id,
+        };
+    }
+
+    /**
+     * Create embed request for Titan
+     */
+    createEmbedReq = async (
+        req: Readonly<AxInternalEmbedRequest<AxAIBedrockEmbedModel>>,
+    ): Promise<[AxAPI, BedrockTitanEmbedRequest]> => {
+        if (!req.texts || req.texts.length === 0) {
+            throw new Error('No texts provided for embedding');
+        }
+
+        const embedRequest: BedrockTitanEmbedRequest = {
+            inputText: req.texts[0], // Take first text
+            dimensions: 512,
+            normalize: true,
+        };
+
+        const apiConfig: AxAPI = {
+            name: 'bedrock-titan-embed',
+            localCall: async <TRequest, TResponse>(data: TRequest) => {
+                const reqBody = data as unknown as BedrockTitanEmbedRequest;
+                const result = await this.invokeWithFailover(req.embedModel, async (client) => {
+                    const command = new InvokeModelCommand({
+                        modelId: req.embedModel,
+                        body: JSON.stringify(reqBody),
+                        contentType: 'application/json',
+                        accept: 'application/json',
+                    });
+                    const response = await client.send(command);
+                    return JSON.parse(new TextDecoder().decode(response.body));
+                });
+                return result as TResponse;
+            },
+        };
+
+        return [apiConfig, embedRequest];
+    };
+
+    /**
+     * Create embed response from Titan
+     */
+    createEmbedResp(resp: Readonly<BedrockTitanEmbedResponse>): AxEmbedResponse {
+        return {
+            embeddings: [resp.embedding],
+        };
+    }
+}
+
+// ============================================================================
+// PROVIDER CLASS - Main entry point
+// ============================================================================
+
+export class AxAIBedrock extends AxBaseAI<
+    AxAIBedrockModel,
+    AxAIBedrockEmbedModel,
+    BedrockChatRequest,
+    BedrockTitanEmbedRequest,
+    BedrockChatResponse,
+    never, // No streaming yet
+    BedrockTitanEmbedResponse,
+    string
+> {
+    constructor({
+        region = 'us-east-2',
+        fallbackRegions = ['us-west-2', 'us-east-1'],
+        gptRegion = 'us-west-2',
+        gptFallbackRegions = ['us-east-1'],
+        config,
+        options,
+    }: Readonly<{
+        region?: string;
+        fallbackRegions?: string[];
+        gptRegion?: string;
+        gptFallbackRegions?: string[];
+        config: Readonly<Partial<AxAIBedrockConfig>>;
+        options?: Readonly<AxAIServiceOptions>;
+    }>) {
+        // Merge user config with defaults
+        const fullConfig: AxAIBedrockConfig = {
+            ...axBaseAIDefaultConfig(),
+            model: AxAIBedrockModel.ClaudeSonnet4,
+            region,
+            fallbackRegions,
+            gptRegion,
+            gptFallbackRegions,
+            ...config,
+        };
+
+        // Create implementation
+        const aiImpl = new AxAIBedrockImpl(
+            fullConfig,
+            region,
+            fallbackRegions,
+            gptRegion,
+            gptFallbackRegions,
+        );
+
+        // Define feature support
+        const supportFor = (): AxAIFeatures => ({
+            functions: false, // Not implemented yet - add when needed
+            streaming: false, // Not implemented yet - add when needed
+            functionCot: false,
+            hasThinkingBudget: false,
+            hasShowThoughts: false,
+            media: {
+                images: {
+                    supported: false, // Add when needed
+                    formats: [],
+                },
+                audio: {
+                    supported: false,
+                    formats: [],
+                },
+                files: {
+                    supported: false,
+                    formats: [],
+                    uploadMethod: 'none',
+                },
+                urls: {
+                    supported: false,
+                    webSearch: false,
+                    contextFetching: false,
+                },
+            },
+            caching: {
+                supported: false,
+                types: [],
+            },
+            thinking: false,
+            multiTurn: true, // All models support multi-turn conversations
+        });
+
+        // Initialize base class
+        super(aiImpl, {
+            name: 'Bedrock',
+            apiURL: '', // Not used - we use SDK directly
+            headers: async () => ({}), // AWS SDK handles auth
+            modelInfo: axModelInfoBedrock,
+            defaults: {
+                model: fullConfig.model,
+                embedModel: fullConfig.embedModel,
+            },
+            options,
+            supportFor,
+        });
+    }
+}
+
+// Re-export types for convenience
+export { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+export type { AxAIBedrockConfig } from './types.js';
+

--- a/src/ax-ai-aws-bedrock/index.ts
+++ b/src/ax-ai-aws-bedrock/index.ts
@@ -1,0 +1,41 @@
+/**
+ * AWS Bedrock Provider for AX
+ * 
+ * Production-ready AWS Bedrock integration supporting Claude, GPT OSS, and Titan Embed models.
+ * 
+ * @example
+ * ```typescript
+ * import { AxAIBedrock, AxAIBedrockModel } from '@ax-llm/ax-ai-aws-bedrock';
+ * 
+ * const ai = new AxAIBedrock({
+ *   region: 'us-east-2',
+ *   config: { model: AxAIBedrockModel.ClaudeSonnet4 }
+ * });
+ * 
+ * const response = await ai.chat({
+ *   chatPrompt: [
+ *     { role: 'system', content: 'You are a helpful assistant.' },
+ *     { role: 'user', content: 'What is AWS Bedrock?' }
+ *   ]
+ * });
+ * ```
+ * 
+ * @packageDocumentation
+ */
+
+export { AxAIBedrock } from './api.js';
+export { axModelInfoBedrock } from './info.js';
+export { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+
+export type {
+    AxAIBedrockConfig,
+    BedrockChatRequest,
+    BedrockChatResponse,
+    BedrockClaudeRequest,
+    BedrockClaudeResponse,
+    BedrockGptRequest,
+    BedrockGptResponse,
+    BedrockTitanEmbedRequest,
+    BedrockTitanEmbedResponse
+} from './types.js';
+

--- a/src/ax-ai-aws-bedrock/info.ts
+++ b/src/ax-ai-aws-bedrock/info.ts
@@ -1,0 +1,70 @@
+/**
+ * Bedrock model information (pricing, limits, features)
+ */
+
+import type { AxModelInfo } from '@ax-llm/ax';
+import { AxAIBedrockEmbedModel, AxAIBedrockModel } from './types.js';
+
+export const axModelInfoBedrock: AxModelInfo[] = [
+    // ========================================================================
+    // Claude Models
+    // ========================================================================
+    {
+        name: AxAIBedrockModel.ClaudeSonnet4,
+        currency: 'usd',
+        promptTokenCostPer1M: 3.0,
+        completionTokenCostPer1M: 15.0,
+        maxTokens: 64000,
+        contextWindow: 200000,
+        supported: { thinkingBudget: true, showThoughts: true },
+    },
+    {
+        name: AxAIBedrockModel.Claude37Sonnet,
+        currency: 'usd',
+        promptTokenCostPer1M: 3.0,
+        completionTokenCostPer1M: 15.0,
+        maxTokens: 64000,
+        contextWindow: 200000,
+    },
+    {
+        name: AxAIBedrockModel.Claude35Sonnet,
+        currency: 'usd',
+        promptTokenCostPer1M: 3.0,
+        completionTokenCostPer1M: 15.0,
+        maxTokens: 8192,
+        contextWindow: 200000,
+    },
+
+    // ========================================================================
+    // GPT OSS Models
+    // ========================================================================
+    {
+        name: AxAIBedrockModel.GptOss120B,
+        currency: 'usd',
+        promptTokenCostPer1M: 0.5,
+        completionTokenCostPer1M: 1.5,
+        maxTokens: 16384,
+        contextWindow: 128000,
+    },
+    {
+        name: AxAIBedrockModel.GptOss20B,
+        currency: 'usd',
+        promptTokenCostPer1M: 0.25,
+        completionTokenCostPer1M: 0.75,
+        maxTokens: 16384,
+        contextWindow: 128000,
+    },
+
+    // ========================================================================
+    // Embed Models
+    // ========================================================================
+    {
+        name: AxAIBedrockEmbedModel.TitanEmbedV2,
+        currency: 'usd',
+        promptTokenCostPer1M: 0.02,
+        completionTokenCostPer1M: 0,
+        maxTokens: 8192,
+        contextWindow: 8192,
+    },
+];
+

--- a/src/ax-ai-aws-bedrock/package.json
+++ b/src/ax-ai-aws-bedrock/package.json
@@ -1,0 +1,54 @@
+{
+    "name": "@ax-llm/ax-ai-aws-bedrock",
+    "version": "14.0.31",
+    "type": "module",
+    "description": "AWS Bedrock Provider for AX - supports Claude, GPT OSS, and Titan Embed models",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ax-llm/ax.git"
+    },
+    "publishConfig": {
+        "access": "public"
+    },
+    "license": "Apache-2.0",
+    "keywords": [
+        "ax",
+        "aws",
+        "bedrock",
+        "claude",
+        "gpt",
+        "llm",
+        "ai"
+    ],
+    "scripts": {
+        "dev": "tsup --watch",
+        "build": "tsup",
+        "clean": "rm -rf dist",
+        "test": "run-s test:*",
+        "test:type-check": "tsc --noEmit",
+        "test:lint": "biome lint .",
+        "test:format": "biome format .",
+        "fix": "run-s fix:*",
+        "fix:lint": "biome lint --write .",
+        "fix:format": "biome format --write .",
+        "tsx": "node --env-file=.env --import=tsx",
+        "release": "release-it",
+        "publish": "npm run build && cd dist && npm publish",
+        "postbuild": "node ../../scripts/postbuild.js"
+    },
+    "dependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.709.0",
+        "@ax-llm/ax": "14.0.31"
+    },
+    "peerDependencies": {
+        "@ax-llm/ax": "14.0.31"
+    },
+    "bugs": {
+        "url": "https://github.com/@ax-llm/ax/issues"
+    },
+    "homepage": "https://github.com/ax-llm/ax#readme",
+    "author": "Vikram <https://twitter.com/dosco>",
+    "files": [
+        "**/*"
+    ]
+}

--- a/src/ax-ai-aws-bedrock/tsconfig.json
+++ b/src/ax-ai-aws-bedrock/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../../tsconfig.json"]
+}

--- a/src/ax-ai-aws-bedrock/tsup.config.ts
+++ b/src/ax-ai-aws-bedrock/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    splitting: false,
+    clean: true,
+    sourcemap: true,
+    minify: false,
+});
+

--- a/src/ax-ai-aws-bedrock/types.ts
+++ b/src/ax-ai-aws-bedrock/types.ts
@@ -1,0 +1,112 @@
+/**
+ * AWS Bedrock provider types for AX integration
+ * Supports Claude, GPT OSS, and Titan models
+ */
+
+import type { AxModelConfig } from '@ax-llm/ax';
+
+// All Bedrock models
+export enum AxAIBedrockModel {
+    // Claude models
+    ClaudeSonnet4 = 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+    Claude37Sonnet = 'anthropic.claude-3-7-sonnet-20250219-v1:0',
+    Claude35Sonnet = 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+
+    // GPT OSS models
+    GptOss120B = 'openai.gpt-oss-120b-1:0',
+    GptOss20B = 'openai.gpt-oss-20b-1:0',
+}
+
+// Embed models
+export enum AxAIBedrockEmbedModel {
+    TitanEmbedV2 = 'amazon.titan-embed-text-v2:0',
+}
+
+export interface AxAIBedrockConfig extends AxModelConfig {
+    model: AxAIBedrockModel;
+    embedModel?: AxAIBedrockEmbedModel;
+    region?: string;
+    fallbackRegions?: string[];
+    gptRegion?: string;
+    gptFallbackRegions?: string[];
+}
+
+// ============================================================================
+// Claude Request/Response Types
+// ============================================================================
+
+export interface BedrockClaudeRequest {
+    anthropic_version: string;
+    max_tokens: number;
+    messages: Array<{
+        role: 'user' | 'assistant';
+        content: string | Array<{ type: 'text'; text: string }>;
+    }>;
+    system?: string;
+    temperature?: number;
+    top_p?: number;
+}
+
+export interface BedrockClaudeResponse {
+    id: string;
+    type: 'message';
+    role: 'assistant';
+    content: Array<{ type: 'text'; text: string }>;
+    model: string;
+    stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence';
+    usage: {
+        input_tokens: number;
+        output_tokens: number;
+    };
+}
+
+// ============================================================================
+// GPT OSS Request/Response Types (OpenAI-compatible format)
+// ============================================================================
+
+export interface BedrockGptRequest {
+    messages: Array<{
+        role: 'system' | 'user' | 'assistant';
+        content: string;
+    }>;
+    max_tokens: number;
+    temperature?: number;
+    top_p?: number;
+}
+
+export interface BedrockGptResponse {
+    id?: string;
+    choices: Array<{
+        index: number;
+        message: {
+            role: 'assistant';
+            content: string | Array<{ type?: string; text?: string; content?: string }>;
+        };
+        finish_reason: 'stop' | 'length' | 'content_filter' | null;
+    }>;
+    usage?: {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+    };
+}
+
+// ============================================================================
+// Titan Embed Request/Response Types
+// ============================================================================
+
+export interface BedrockTitanEmbedRequest {
+    inputText: string;
+    dimensions?: number;
+    normalize?: boolean;
+}
+
+export interface BedrockTitanEmbedResponse {
+    embedding: number[];
+    inputTextTokenCount: number;
+}
+
+// Union types for all models
+export type BedrockChatRequest = BedrockClaudeRequest | BedrockGptRequest;
+export type BedrockChatResponse = BedrockClaudeResponse | BedrockGptResponse;
+


### PR DESCRIPTION
feat: add AWS Bedrock provider implementation

### Summary
Adds initial support for AWS Bedrock through a new package `src/ax-ai-aws-bedrock`.
Uses the AWS SDK's BedrockRuntimeClient and InvokeModelCommand.

### Notes
- No external deps in core `ax` package.
- Tested with Claude Sonnet 4 and OSS 20B/120B models.
