### PR TITLE
Fix: Hardcode error class names to prevent minification issues

### DIFF
--- a/src/ax/dsp/asserts.ts
+++ b/src/ax/dsp/asserts.ts
@@ -20,7 +20,7 @@ export class AxAssertionError extends Error {
     message: string;
   }>) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'AxAssertionError';
   }
 
   public getFixingInstructions = () => {

--- a/src/ax/dsp/errors.ts
+++ b/src/ax/dsp/errors.ts
@@ -44,7 +44,7 @@ const toFieldType = (type: Readonly<AxField['type']>) => {
 export class ValidationError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'ValidationError';
   }
 
   public getFixingInstructions = () => {

--- a/src/ax/dsp/functions.ts
+++ b/src/ax/dsp/functions.ts
@@ -44,7 +44,7 @@ export class AxFunctionError extends Error {
     }[]
   ) {
     super();
-    this.name = this.constructor.name;
+    this.name = 'AxFunctionError';
   }
 
   getFields = () => this.fields;

--- a/src/ax/util/apicall.ts
+++ b/src/ax/util/apicall.ts
@@ -86,7 +86,7 @@ export class AxAIServiceError extends Error {
     context: Record<string, unknown> = {}
   ) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceError';
     this.timestamp = new Date().toISOString();
     this.errorId = randomUUID();
     this.context = context;
@@ -132,7 +132,7 @@ export class AxAIServiceStatusError extends AxAIServiceError {
       responseBody,
       ...context,
     });
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceStatusError';
   }
 }
 
@@ -155,7 +155,7 @@ export class AxAIServiceNetworkError extends AxAIServiceError {
         ...context,
       }
     );
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceNetworkError';
     this.stack = originalError.stack;
   }
 }
@@ -168,7 +168,7 @@ export class AxAIServiceResponseError extends AxAIServiceError {
     context?: Record<string, unknown>
   ) {
     super(message, url, requestBody, undefined, context);
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceResponseError';
   }
 }
 
@@ -189,7 +189,7 @@ export class AxAIServiceStreamTerminatedError extends AxAIServiceError {
         ...context,
       }
     );
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceStreamTerminatedError';
   }
 }
 
@@ -207,7 +207,7 @@ export class AxAIServiceTimeoutError extends AxAIServiceError {
       undefined,
       { timeoutMs, ...context }
     );
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceTimeoutError';
   }
 }
 
@@ -225,7 +225,7 @@ export class AxAIServiceAbortedError extends AxAIServiceError {
       undefined,
       { abortReason: reason, ...context }
     );
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceAbortedError';
   }
 }
 
@@ -237,7 +237,7 @@ export class AxAIServiceAuthenticationError extends AxAIServiceError {
     context?: Record<string, unknown>
   ) {
     super('Authentication failed', url, requestBody, responseBody, context);
-    this.name = this.constructor.name;
+    this.name = 'AxAIServiceAuthenticationError';
   }
 }
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

I noticed when logging `AxAssertionError`s that the message/stack trace was prefixed with `Qe`:

```ts
const err = new AxAssertionError({ message: "foo bar" });

// prints `Qe: foo bar`
console.log(err);

// prints:
// AxAssertionError: foo bar
//     at file:///path/to/script.ts
console.log(err.stack);
```

In the minified source, it looks like the name of the actual error class is getting mangled to "Qe":

<img width="1176" height="150" alt="Screenshot 2025-11-04 at 5 27 54 PM" src="https://github.com/user-attachments/assets/c2894f02-d9a8-48b7-a283-d61c80199bc3" />

<img width="524" height="169" alt="Screenshot 2025-11-04 at 4 57 10 PM" src="https://github.com/user-attachments/assets/c40ea2f3-39b5-4bb2-9870-adb0390bda27" />

Since that class sets its name like `this.name = this.constructor.name`, the mangling was changing the stringified output.

- **What is the new behavior (if this is a feature change)?**

This PR just hardcodes the names, so it should fix how the errors are printed. 

I applied the same change everywhere else I saw this pattern, which should avoid this issue. That said, I'm happy to edit it down if this change is unnecessary elsewhere. 

- **Other information**:

Alternatively, the minify config could be altered not to mangle class names / error class names.