### PR TITLE
feat(anthropic): update and align Claude model names of Vertex AI

### DIFF
--- a/src/ax/ai/anthropic/info.ts
+++ b/src/ax/ai/anthropic/info.ts
@@ -1,6 +1,6 @@
 import type { AxModelInfo } from '../types.js';
 
-import { AxAIAnthropicModel } from './types.js';
+import { AxAIAnthropicModel, AxAIAnthropicVertexModel } from './types.js';
 
 export const axModelInfoAnthropic: AxModelInfo[] = [
   // 4.5 Sonnet (2025-09)
@@ -8,6 +8,14 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
     name: AxAIAnthropicModel.Claude45Sonnet,
     currency: 'usd',
     // Estimated/prior pricing aligned with Sonnet tier
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 200000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude45Sonnet,
+    currency: 'usd',
     promptTokenCostPer1M: 3.0,
     completionTokenCostPer1M: 15.0,
     maxTokens: 200000,
@@ -23,9 +31,25 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
     maxTokens: 200000, // match modern context window similar to Sonnet 4.5 era
     supported: { thinkingBudget: true, showThoughts: true },
   },
+  {
+    name: AxAIAnthropicVertexModel.Claude45Haiku,
+    currency: 'usd',
+    promptTokenCostPer1M: 1.0,
+    completionTokenCostPer1M: 5.0,
+    maxTokens: 200000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
   // 4
   {
     name: AxAIAnthropicModel.Claude41Opus,
+    currency: 'usd',
+    promptTokenCostPer1M: 15.0,
+    completionTokenCostPer1M: 75.0,
+    maxTokens: 32000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude41Opus,
     currency: 'usd',
     promptTokenCostPer1M: 15.0,
     completionTokenCostPer1M: 75.0,
@@ -41,7 +65,23 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
     supported: { thinkingBudget: true, showThoughts: true },
   },
   {
+    name: AxAIAnthropicVertexModel.Claude4Opus,
+    currency: 'usd',
+    promptTokenCostPer1M: 15.0,
+    completionTokenCostPer1M: 75.0,
+    maxTokens: 32000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
     name: AxAIAnthropicModel.Claude4Sonnet,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 64000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude4Sonnet,
     currency: 'usd',
     promptTokenCostPer1M: 3.0,
     completionTokenCostPer1M: 15.0,
@@ -57,6 +97,14 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
     maxTokens: 64000,
     supported: { thinkingBudget: true, showThoughts: true },
   },
+  {
+    name: AxAIAnthropicVertexModel.Claude37Sonnet,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 64000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
   // 3.5
   {
     name: AxAIAnthropicModel.Claude35Sonnet,
@@ -66,15 +114,44 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
     maxTokens: 8192,
   },
   {
+    name: AxAIAnthropicVertexModel.Claude35Sonnet,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 8192,
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude35SonnetV2,
+    currency: 'usd',
+    promptTokenCostPer1M: 3.0,
+    completionTokenCostPer1M: 15.0,
+    maxTokens: 8192,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
     name: AxAIAnthropicModel.Claude35Haiku,
     currency: 'usd',
     promptTokenCostPer1M: 0.8,
     completionTokenCostPer1M: 4.0,
     maxTokens: 8192,
   },
+  {
+    name: AxAIAnthropicVertexModel.Claude35Haiku,
+    currency: 'usd',
+    promptTokenCostPer1M: 1.0,
+    completionTokenCostPer1M: 5.0,
+    maxTokens: 8192,
+  },
   // 3
   {
     name: AxAIAnthropicModel.Claude3Opus,
+    currency: 'usd',
+    promptTokenCostPer1M: 15.0,
+    completionTokenCostPer1M: 75.0,
+    maxTokens: 4096,
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude3Opus,
     currency: 'usd',
     promptTokenCostPer1M: 15.0,
     completionTokenCostPer1M: 75.0,
@@ -89,6 +166,13 @@ export const axModelInfoAnthropic: AxModelInfo[] = [
   },
   {
     name: AxAIAnthropicModel.Claude3Haiku,
+    currency: 'usd',
+    promptTokenCostPer1M: 0.25,
+    completionTokenCostPer1M: 1.25,
+    maxTokens: 4096,
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude3Haiku,
     currency: 'usd',
     promptTokenCostPer1M: 0.25,
     completionTokenCostPer1M: 1.25,

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -20,12 +20,17 @@ export enum AxAIAnthropicModel {
 }
 
 export enum AxAIAnthropicVertexModel {
-  Claude37Sonnet = 'claude-3-7-sonnet',
-  Claude35Haiku = 'claude-3-5-haiku',
-  Claude35Sonnet = 'claude-3-5-sonnet',
-  Claude35SonnetV2 = 'claude-3-5-sonnet-v2',
-  Claude3Haiku = 'claude-3-haiku',
-  Claude3Opus = 'claude-3-opus',
+  Claude41Opus = 'claude-opus-4-1@20250805',
+  Claude4Opus = 'claude-opus-4@20250514',
+  Claude45Sonnet = 'claude-sonnet-4-5@20250929',
+  Claude4Sonnet = 'claude-sonnet-4@20250514',
+  Claude37Sonnet = 'claude-3-7-sonnet@20250219',
+  Claude35SonnetV2 = 'claude-3-5-sonnet-v2@20241022',
+  Claude45Haiku = 'claude-haiku-4.5@20251001',
+  Claude35Haiku = 'claude-3-5-haiku@20241022',
+  Claude35Sonnet = 'claude-3-5-sonnet@20240620',
+  Claude3Opus = 'claude-3-opus@20240229',
+  Claude3Haiku = 'claude-3-haiku@20240307',
 }
 
 export type AxAIAnthropicThinkingConfig = {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  - feature (Adds support for new models) and bug fix (Corrects inaccuracies in existing Vertex AI model IDs and addresses missing model information).

- **What is the current behavior?** (You can also link to an open issue here)
  -  The AxAIAnthropicVertexModel enum, which defines Anthropic models for Vertex AI, did not reflect the latest model lineup. Specifically, newer models such as Claude Opus 4/4.1, Claude Sonnet 4/4.5, and Claude Haiku 4.5 were missing.
  -  Existing models (e.g., claude-3-7-sonnet) did not use the date-suffixed version identifiers required by Vertex AI (e.g., claude-3-7-sonnet@20250219).
  - src/ax/ai/anthropic/info.ts lacked model information (cost, context window, etc.) corresponding to the AxAIAnthropicVertexModel entries, which prevented the getModelInfo function from retrieving accurate details.
   - The latest and right model list is available at https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/use-claude?hl=en

- **What is the new behavior (if this is a feature change)?**
  - The AxAIAnthropicVertexModel enum in src/ax/ai/anthropic/types.ts has been updated to include and use the latest specified Vertex AI Anthropic model IDs (including date-suffixed versions). This allows the library to support a broader range of available models directly.
  - Corresponding model information has been added to src/ax/ai/anthropic/info.ts for each AxAIAnthropicVertexModel entry. This enables accurate cost calculation, context window management, and precise feature support determination for these         models.

- **Other information**:
