### PR TITLE
fix(vertex): use correct Vertex AI endpoint for global region

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -810,7 +810,8 @@ export class AxAIAnthropic<TModelKey = string> extends AxBaseAI<
           'Anthropic Vertex API key must be a function for token-based authentication'
         );
       }
-      apiURL = `https://${region}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${region}/publishers/anthropic/`;
+      const tld = region === 'global' ? 'aiplatform' : `${region}-aiplatform`;
+      apiURL = `https://${tld}.googleapis.com/v1/projects/${projectId}/locations/${region}/publishers/anthropic/`;
       headers = async () => ({
         Authorization: `Bearer ${await apiKey()}`,
       });


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
    * bug fix (Corrects the API endpoint construction for the Vertex AI 'global' region).

* **What is the current behavior?**
    * When a user configured the Anthropic provider (and potentially others following the same pattern on Vertex AI) with region: 'global', the library incorrectly constructed the API endpoint as https://global-aiplatform.googleapis.com/.... This is an invalid endpoint for Vertex AI.

* **What is the new behavior (if this is a feature change)?**
    * The library now correctly constructs the API endpoint for the 'global' region as https://aiplatform.googleapis.com/... (without the region prefix).
    * For all other regions (e.g., us-central1), it continues to use the ${region}-aiplatform.googleapis.com format.

* **Other information:**

