### PR TITLE
feat(google-gemini): add Gemini 3 Pro Preview model with updated pric…

### DIFF
--- a/src/ax/ai/google-gemini/info.ts
+++ b/src/ax/ai/google-gemini/info.ts
@@ -7,6 +7,14 @@ import { AxAIGoogleGeminiModel } from './types.js';
  */
 export const axModelInfoGoogleGemini: AxModelInfo[] = [
   {
+    name: AxAIGoogleGeminiModel.Gemini3Pro,
+    currency: 'usd',
+    characterIsToken: false,
+    promptTokenCostPer1M: 4.0,
+    completionTokenCostPer1M: 18.0,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
     name: AxAIGoogleGeminiModel.Gemini25Pro,
     currency: 'usd',
     characterIsToken: false,

--- a/src/ax/ai/google-gemini/types.ts
+++ b/src/ax/ai/google-gemini/types.ts
@@ -1,6 +1,7 @@
 import type { AxModelConfig } from '../types.js';
 
 export enum AxAIGoogleGeminiModel {
+  Gemini3Pro = 'gemini-3-pro-preview',
   Gemini25Pro = 'gemini-2.5-pro',
   Gemini25Flash = 'gemini-2.5-flash',
   Gemini25FlashLite = 'gemini-2.5-flash-lite',


### PR DESCRIPTION
* What kind of change does this PR introduce?
    * feature (Adds support for the new Google Gemini 3.0 Pro model).

* What is the current behavior?
    * The library did not support the newly announced/released gemini-3.0-pro model.

* What is the new behavior (if this is a feature change)?
    * Added Gemini30Pro (gemini-3.0-pro) to the AxAIGoogleGeminiModel enum.
    * Added model information for gemini-3.0-pro to axModelInfoGoogleGemini, including
      pricing
    * Pricing has been set to Input: $4.00, Output: $18.00 per 1M tokens, based on "Price (/1M tokens) > 200K input tokens". 

* Other information:

https://cloud.google.com/vertex-ai/generative-ai/pricing
https://docs.cloud.google.com/vertex-ai/generative-ai/docs/start/get-started-with-gemini-3