### PR TITLE
fix(anthropic): add anthropic-beta header for web-search on Vertex AI

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -884,7 +884,7 @@ export class AxAIAnthropic<TModelKey = string> extends AxBaseAI<
       apiURL = `https://${tld}.googleapis.com/v1/projects/${projectId}/locations/${region}/publishers/anthropic/`;
       headers = async () => ({
         Authorization: `Bearer ${await apiKey()}`,
-        'anthropic-beta': 'web-search-2025-03-05',
+        'anthropic-beta': 'structured-outputs-2025-11-13, web-search-2025-03-05',
       });
     } else {
       if (!apiKey) {


### PR DESCRIPTION
- What kind of change does this PR introduce?
  - Bug fix
- What is the current behavior?
  - When using the Anthropic API via Vertex AI, attempting to use the web_search tool results in a 400 Bad Request error. The error message shows:
    ```
    tools.0: Input tag 'web_search_20250305' found using 'type' does not match any of the expected tags: 'bash_20250124', 'custom', 'text_editor_20250124',
    'text_editor_20250429', 'text_editor_20250728'
    ```
- What is the new behavior (if this is a feature change)?
  - By adding the anthropic-beta: web-search-2025-03-05 header to Vertex AI Anthropic API requests, the web_search tool now works correctly.
- Other information:
  - To use Anthropic beta features (such as web_search) via Vertex AI, the appropriate anthropic-beta header must be included. This change enables the web_search functionality on
    Vertex AI.
  - ref: https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/web-search
