### PR TITLE
fix(anthropic): remove unsupported structured-outputs beta header for Vertex AI

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -878,8 +878,7 @@ export class AxAIAnthropic<TModelKey = string> extends AxBaseAI<
       apiURL = `https://${tld}.googleapis.com/v1/projects/${projectId}/locations/${region}/publishers/anthropic/`;
       headers = async () => ({
         Authorization: `Bearer ${await apiKey()}`,
-        'anthropic-beta':
-          'structured-outputs-2025-11-13, web-search-2025-03-05',
+        'anthropic-beta': 'web-search-2025-03-05',
       });
     } else {
       if (!apiKey) {


### PR DESCRIPTION
## Summary
- Remove `structured-outputs-2025-11-13` beta header for Vertex AI Anthropic integration
- This header is not supported by Vertex AI and causes `invalid_request_error` responses
- Keep `web-search-2025-03-05` header which is supported

```
  Response Body: {
    "httpStatus": 400,
    "httpStatusText": "Bad Request",
    "responseBody": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Unexpected value(s) `structured-outputs-2025-11-13` for the `anthropic-beta` header. Please consult our documentation at docs.anthropic.com or try again without the header.\"},\"request_id\":\"req_vrtx_XXXXXXXXXX\"}",
    "metrics": {
      "startTime": 1764679274337,
      "retryCount": 0
    }
  }
```

Related to #457

