### PR TITLE
fix(dsp): correctly extract instruction from signature in GEPA optimizer

### DIFF
--- a/src/ax/dsp/generate.ts
+++ b/src/ax/dsp/generate.ts
@@ -180,6 +180,10 @@ export class AxGen<IN = any, OUT extends AxGenOut = any>
     this.promptTemplate.setInstruction(instruction);
   }
 
+  public getInstruction(): string | undefined {
+    return this.promptTemplate.getInstruction();
+  }
+
   private getSignatureName(): string {
     return this.signature.getDescription() || 'unknown_signature';
   }

--- a/src/ax/dsp/optimizers/gepa.test.ts
+++ b/src/ax/dsp/optimizers/gepa.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { ax } from '../template.js';
+import type { AxAIService } from '../../ai/types.js';
+import { AxGEPA } from './gepa.js';
+
+describe('AxGEPA Optimizer', () => {
+  describe('getBaseInstruction', () => {
+    it('should use the description from the signature when available', async () => {
+      // Create a program with a signature that has a description
+      const program = ax(
+        '"This is my custom task description" question:string -> answer:string'
+      );
+
+      // Access the private method via cast
+      const optimizer = new AxGEPA({
+        studentAI: {} as AxAIService,
+        teacherAI: {} as AxAIService,
+      });
+
+      // Call getBaseInstruction
+      const instruction = await (optimizer as any).getBaseInstruction(program);
+
+      // It should return the description from the signature, not the default
+      expect(instruction).toBe('This is my custom task description');
+      expect(instruction).not.toBe(
+        'Follow the task precisely. Be concise, correct, and consistent.'
+      );
+    });
+
+    it('should fall back to default when signature has no description', async () => {
+      // Create a program without a description
+      const program = ax('question:string -> answer:string');
+
+      const optimizer = new AxGEPA({
+        studentAI: {} as AxAIService,
+        teacherAI: {} as AxAIService,
+      });
+
+      const instruction = await (optimizer as any).getBaseInstruction(program);
+
+      // Should use the default fallback
+      expect(instruction).toBe(
+        'Follow the task precisely. Be concise, correct, and consistent.'
+      );
+    });
+
+    it('should use custom instruction when set via setInstruction', async () => {
+      const program = ax('question:string -> answer:string');
+      program.setInstruction('My explicitly set custom instruction');
+
+      const optimizer = new AxGEPA({
+        studentAI: {} as AxAIService,
+        teacherAI: {} as AxAIService,
+      });
+
+      const instruction = await (optimizer as any).getBaseInstruction(program);
+
+      // Should return the custom instruction
+      expect(instruction).toBe('My explicitly set custom instruction');
+    });
+  });
+});

--- a/src/ax/dsp/optimizers/gepa.ts
+++ b/src/ax/dsp/optimizers/gepa.ts
@@ -836,17 +836,19 @@ export class AxGEPA extends AxBaseOptimizer {
   private async getBaseInstruction<IN, OUT extends AxGenOut>(
     program: Readonly<AxGen<IN, OUT>>
   ): Promise<string> {
-    try {
-      // If program exposes instruction via signature, prefer it
-      const sig: any = program.getSignature?.();
-      if (
-        sig &&
-        typeof sig.instruction === 'string' &&
-        sig.instruction.length > 0
-      ) {
-        return sig.instruction as string;
-      }
-    } catch {}
+    // First check for custom instruction set via setInstruction()
+    const customInstruction = program.getInstruction?.();
+    if (customInstruction && customInstruction.length > 0) {
+      return customInstruction;
+    }
+
+    // Fall back to signature description
+    const sig = program.getSignature?.();
+    const description = sig?.getDescription?.();
+    if (description && description.length > 0) {
+      return description;
+    }
+
     return 'Follow the task precisely. Be concise, correct, and consistent.';
   }
 

--- a/src/ax/dsp/optimizers/gepaFlow.ts
+++ b/src/ax/dsp/optimizers/gepaFlow.ts
@@ -830,15 +830,19 @@ export class AxGEPAFlow extends AxBaseOptimizer {
 
   // === Helpers ===
   private async getBaseInstruction(program: any): Promise<string> {
-    try {
-      const sig = program?.getSignature?.();
-      if (
-        sig &&
-        typeof sig.instruction === 'string' &&
-        sig.instruction.length > 0
-      )
-        return sig.instruction as string;
-    } catch {}
+    // First check for custom instruction set via setInstruction()
+    const customInstruction = program?.getInstruction?.();
+    if (customInstruction && customInstruction.length > 0) {
+      return customInstruction;
+    }
+
+    // Fall back to signature description
+    const sig = program?.getSignature?.();
+    const description = sig?.getDescription?.();
+    if (description && description.length > 0) {
+      return description;
+    }
+
     return 'Follow the task precisely. Be concise, correct, and consistent.';
   }
 

--- a/src/ax/dsp/prompt.ts
+++ b/src/ax/dsp/prompt.ts
@@ -46,9 +46,15 @@ export class AxPromptTemplate {
   private sig: Readonly<AxSignature>;
   private fieldTemplates?: Record<string, AxFieldTemplateFn>;
   private task: { type: 'text'; text: string };
+  private customInstruction?: string;
 
   public setInstruction(instruction: string): void {
+    this.customInstruction = instruction;
     this.task = { type: 'text', text: instruction };
+  }
+
+  public getInstruction(): string | undefined {
+    return this.customInstruction;
   }
   private readonly thoughtFieldName: string;
   private readonly functions?: Readonly<AxInputFunctionType>;


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

The GEPA optimizer accesses `sig.instruction` which doesn't exist on `AxSignature`, causing it to always fall back to the default instruction `'Follow the task precisely. Be concise, correct, and consistent.'` instead of using the user's signature description or custom instruction.

Fixes #463

- **What is the new behavior (if this is a feature change)?**

The `getBaseInstruction()` method now correctly:
1. First checks for custom instruction set via `program.getInstruction()`
2. Falls back to signature description via `sig.getDescription()`
3. Only uses default fallback if neither is available

- **Other information**:

Changes made:
- Added `customInstruction` field and `getInstruction()` method to `AxPromptTemplate`
- Added `getInstruction()` method to `AxGen`
- Fixed `getBaseInstruction()` in both `gepa.ts` and `gepaFlow.ts`
- Added unit tests to verify instruction extraction works correctly

Tested with real OpenAI API calls to confirm the fix works end-to-end.