### PR TITLE
feat: add support for Claude 4.5 Opus model

### DIFF
--- a/src/aws-bedrock/info.ts
+++ b/src/aws-bedrock/info.ts
@@ -10,6 +10,15 @@ export const axModelInfoBedrock: AxModelInfo[] = [
   // Claude Models
   // ========================================================================
   {
+    name: AxAIBedrockModel.ClaudeOpus45,
+    currency: 'usd',
+    promptTokenCostPer1M: 5.0,
+    completionTokenCostPer1M: 25.0,
+    maxTokens: 64000,
+    contextWindow: 200000,
+    supported: { thinkingBudget: true, showThoughts: true },
+  },
+  {
     name: AxAIBedrockModel.ClaudeSonnet4,
     currency: 'usd',
     promptTokenCostPer1M: 3.0,

--- a/src/aws-bedrock/types.ts
+++ b/src/aws-bedrock/types.ts
@@ -8,6 +8,7 @@ import type { AxModelConfig } from '@ax-llm/ax';
 // All Bedrock models
 export enum AxAIBedrockModel {
   // Claude models
+  ClaudeOpus45 = 'us.anthropic.claude-opus-4-5-20251101-v1:0',
   ClaudeSonnet4 = 'us.anthropic.claude-sonnet-4-20250514-v1:0',
   Claude37Sonnet = 'anthropic.claude-3-7-sonnet-20250219-v1:0',
   Claude35Sonnet = 'anthropic.claude-3-5-sonnet-20240620-v1:0',

--- a/src/ax/ai/anthropic/info.ts
+++ b/src/ax/ai/anthropic/info.ts
@@ -3,6 +3,31 @@ import type { AxModelInfo } from '../types.js';
 import { AxAIAnthropicModel, AxAIAnthropicVertexModel } from './types.js';
 
 export const axModelInfoAnthropic: AxModelInfo[] = [
+  // 4.5 Opus (2025-11)
+  {
+    name: AxAIAnthropicModel.Claude45Opus,
+    currency: 'usd',
+    promptTokenCostPer1M: 5.0,
+    completionTokenCostPer1M: 25.0,
+    maxTokens: 64000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+    },
+  },
+  {
+    name: AxAIAnthropicVertexModel.Claude45Opus,
+    currency: 'usd',
+    promptTokenCostPer1M: 5.0,
+    completionTokenCostPer1M: 25.0,
+    maxTokens: 64000,
+    supported: {
+      thinkingBudget: true,
+      showThoughts: true,
+      structuredOutputs: true,
+    },
+  },
   // 4.5 Sonnet (2025-09)
   {
     name: AxAIAnthropicModel.Claude45Sonnet,

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -1,6 +1,7 @@
 import type { AxModelConfig } from '../types.js';
 
 export enum AxAIAnthropicModel {
+  Claude45Opus = 'claude-opus-4-5-20251101',
   Claude41Opus = 'claude-opus-4-1-20250805',
   Claude4Opus = 'claude-opus-4-20250514',
   Claude4Sonnet = 'claude-sonnet-4-20250514',
@@ -20,6 +21,7 @@ export enum AxAIAnthropicModel {
 }
 
 export enum AxAIAnthropicVertexModel {
+  Claude45Opus = 'claude-opus-4-5@20251101',
   Claude41Opus = 'claude-opus-4-1@20250805',
   Claude4Opus = 'claude-opus-4@20250514',
   Claude45Sonnet = 'claude-sonnet-4-5@20250929',


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature

## What is the current behavior?
Claude 4.5 Opus model is not supported.

## What is the new behavior?
Add Claude 4.5 Opus (claude-opus-4-5-20251101) to supported models:
- Anthropic API direct access
- Vertex AI integration
- AWS Bedrock integration

Includes pricing info  and feature flags (thinking budget, show thoughts, structured outputs).

model spec: https://platform.claude.com/docs/en/about-claude/models/overview
model pricing: https://platform.claude.com/docs/en/about-claude/pricing