### PR TITLE
feat(azure-openai): enable structured outputs

### DIFF
--- a/src/ax/ai/azure-openai/api.test.ts
+++ b/src/ax/ai/azure-openai/api.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { AxAIOpenAIModel } from '../openai/chat_types.js';
+import { AxAIAzureOpenAI } from './api.js';
+
+const createAI = (version: string) =>
+  new AxAIAzureOpenAI({
+    apiKey: 'key',
+    resourceName: 'https://example.openai.azure.com/',
+    deploymentName: 'deployment',
+    version,
+  });
+
+describe('AxAIAzureOpenAI structured outputs support', () => {
+  it('should not advertise structured outputs for older Azure API versions', () => {
+    const ai = createAI('2024-02-15-preview');
+    const features = ai.getFeatures(AxAIOpenAIModel.GPT5Mini);
+    expect(features.structuredOutputs).toBe(false);
+  });
+
+  it('should advertise structured outputs for Azure API versions that support it', () => {
+    const ai = createAI('2024-08-01-preview');
+    const features = ai.getFeatures(AxAIOpenAIModel.GPT5Mini);
+    expect(features.structuredOutputs).toBe(true);
+  });
+
+  it('should accept api-version= prefix in version argument', () => {
+    const ai = createAI('api-version=2024-10-21');
+    const features = ai.getFeatures(AxAIOpenAIModel.GPT5Mini);
+    expect(features.structuredOutputs).toBe(true);
+
+    // Ensure we don't generate malformed query strings like api-version=api-version=...
+    expect((ai as any).apiURL).toContain('api-version=2024-10-21');
+    expect((ai as any).apiURL).not.toContain('api-version=api-version=');
+  });
+});


### PR DESCRIPTION
- **What kind of change does this PR introduce?**  
  Feature + tests (Azure OpenAI provider now advertises structured outputs capability when supported by the Azure API version; adds unit coverage).

- **What is the current behavior?**  
  Using Azure OpenAI with complex structured outputs (object/array) can fail early with:  
  `Complex structured outputs (object/array types) require a provider that supports structured outputs...`  
  because the Azure provider does not advertise `structuredOutputs` support even when the underlying model/API version supports it.

- **What is the new behavior (if this is a feature change)?**  
  [AxAIAzureOpenAI](cci:2://file:///home/arch/workspace/ax/src/ax/ai/azure-openai/api.ts:65:0-177:1) now:
  - normalizes the provided `version` (supports both `2024-10-21` and `api-version=2024-10-21`)
  - gates `structuredOutputs` support based on Azure API version (>= `2024-08-01...`) and model capability (`axModelInfoOpenAI`)
  - ensures the generated Azure API URL contains a single `api-version=` parameter

  Added unit tests covering:
  - old Azure API version => `structuredOutputs: false`
  - supported Azure API version => `structuredOutputs: true`
  - `api-version=` prefix normalization + no double `api-version=api-version=`
