### PR TITLE
fix: correct Claude 4.5 Haiku model name in Vertex enum

### DIFF
--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -28,7 +28,7 @@ export enum AxAIAnthropicVertexModel {
   Claude4Sonnet = 'claude-sonnet-4@20250514',
   Claude37Sonnet = 'claude-3-7-sonnet@20250219',
   Claude35SonnetV2 = 'claude-3-5-sonnet-v2@20241022',
-  Claude45Haiku = 'claude-haiku-4.5@20251001',
+  Claude45Haiku = 'claude-haiku-4-5@20251001',
   Claude35Haiku = 'claude-3-5-haiku@20241022',
   Claude35Sonnet = 'claude-3-5-sonnet@20240620',
   Claude3Opus = 'claude-3-opus@20240229',


### PR DESCRIPTION
## Summary
- Fix typo in `AxAIAnthropicVertexModel.Claude45Haiku`: `claude-haiku-4.5@20251001` → `claude-haiku-4-5@20251001`
- The model ID should use hyphens instead of dots to match the standard naming convention used by all other Claude models

## Test plan
- Verified all other model names in the file use the hyphen format (`4-5`, not `4.5`)