### PR TITLE
Write metrics for cache write / read

### DIFF
--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -17,6 +17,7 @@ import {
   type AxAIMetricsInstruments,
   getOrCreateAIMetricsInstruments,
   recordAbortMetric,
+  recordCacheTokenMetric,
   recordContextWindowUsageMetric,
   recordErrorMetric,
   recordErrorRateMetric,
@@ -583,8 +584,14 @@ export class AxBaseAI<
   private recordTokenUsage(modelUsage?: AxModelUsage): void {
     const metricsInstruments = this.getMetricsInstruments();
     if (metricsInstruments && modelUsage?.tokens) {
-      const { promptTokens, completionTokens, totalTokens, thoughtsTokens } =
-        modelUsage.tokens;
+      const {
+        promptTokens,
+        completionTokens,
+        totalTokens,
+        thoughtsTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+      } = modelUsage.tokens;
 
       if (promptTokens) {
         recordTokenMetric(
@@ -621,6 +628,26 @@ export class AxBaseAI<
           metricsInstruments,
           'thoughts',
           thoughtsTokens,
+          this.name,
+          modelUsage.model
+        );
+      }
+
+      if (cacheReadTokens) {
+        recordCacheTokenMetric(
+          metricsInstruments,
+          'read',
+          cacheReadTokens,
+          this.name,
+          modelUsage.model
+        );
+      }
+
+      if (cacheCreationTokens) {
+        recordCacheTokenMetric(
+          metricsInstruments,
+          'write',
+          cacheCreationTokens,
           this.name,
           modelUsage.model
         );


### PR DESCRIPTION
## Summary

Adds OpenTelemetry metrics for prompt caching token usage. This enables observability into cache hit/miss patterns when using providers that support prompt caching (e.g., Anthropic).

## Changes

### `src/ax/ai/metrics.ts`

- Added `cacheReadTokensCounter` and `cacheWriteTokensCounter` to the `AxAIMetricsInstruments` interface
- Created two new counter metrics:
  - `ax_llm_cache_read_tokens_total` - tracks tokens read from cache (cache hits)
  - `ax_llm_cache_write_tokens_total` - tracks tokens written to cache (cache creation)
- Added `recordCacheTokenMetric()` function to record cache token usage with proper label sanitization and error handling

### `src/ax/ai/base.ts`

- Imported the new `recordCacheTokenMetric` function
- Updated `recordTokenUsage()` to extract `cacheReadTokens` and `cacheCreationTokens` from model usage
- Added calls to record cache metrics when these values are present in the response