### PR TITLE
Fix: include cache_control for string-typed user messages

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -1083,6 +1083,9 @@ function createMessages(
           return {
             role: 'user' as const,
             content: msg.content,
+            ...(msg.cache
+              ? { cache_control: { type: 'ephemeral' as const } }
+              : {}),
           };
         }
         const content = msg.content.map((v) => {


### PR DESCRIPTION
## Bug Fix

Adds `cache_control` support for user messages with string content in the Anthropic API.

### Problem

When using Anthropic's prompt caching with few-shot examples rendered as separate user/assistant message pairs, the `cache_control` field was not being added to user messages that have string content (as opposed to array content with typed parts).

In the `createMessages` function, the user message case handled array content correctly by checking `v.cache` on each content part, but the string content branch returned early without checking `msg.cache`:

```typescript
if (typeof msg.content === 'string') {
  return {
    role: 'user' as const,
    content: msg.content,
    // cache_control was missing here!
  };
}
```

This caused prompt caching to fail for messages like the "END OF EXAMPLES" separator that is added between few-shot demonstrations and the actual user query.

### Solution

Added the `cache_control` spread to the string content branch, consistent with how other message types handle caching:

```typescript
if (typeof msg.content === 'string') {
  return {
    role: 'user' as const,
    content: msg.content,
    ...(msg.cache
      ? { cache_control: { type: 'ephemeral' as const } }
      : {}),
  };
}
```

### Impact

Users relying on Anthropic's prompt caching with the v16 example rendering (where examples are rendered as separate message pairs rather than embedded in the system prompt) will now see proper cache token usage.