### PR TITLE
Fix: use cache_control on a content block, not the content itself

### DIFF
--- a/src/ax/ai/anthropic/api.ts
+++ b/src/ax/ai/anthropic/api.ts
@@ -1210,6 +1210,32 @@ function createMessages(
             ];
           }
         }
+
+        // Add cache_control to the last content block (not the message itself). The
+        // Anthropic API does not support cache_control on the message itself.
+        if (msg.cache) {
+          if (typeof content === 'string') {
+            // Convert string to array with text block containing cache_control
+            content = [
+              {
+                type: 'text' as const,
+                text: content,
+                cache_control: { type: 'ephemeral' as const },
+              },
+            ];
+          } else if (Array.isArray(content) && content.length > 0) {
+            // Add cache_control to the last text or tool_use block
+            const lastIdx = content.length - 1;
+            const lastBlock = content[lastIdx];
+            if (lastBlock && lastBlock.type === 'text') {
+              content[lastIdx] = {
+                ...lastBlock,
+                cache_control: { type: 'ephemeral' as const },
+              };
+            }
+          }
+        }
+
         return {
           role: 'assistant' as const,
           content,

--- a/src/ax/ai/anthropic/types.ts
+++ b/src/ax/ai/anthropic/types.ts
@@ -137,8 +137,10 @@ export type AxAIAnthropicChatRequest = {
         content:
           | string
           | (
-              | { type: 'text'; text: string }
-              | { type: 'tool_use'; id: string; name: string; input: object }
+              | ({
+                  type: 'text';
+                  text: string;
+                } & AxAIAnthropicChatRequestCacheParam)
               | { type: 'thinking'; thinking: string; signature?: string }
               | {
                   type: 'redacted_thinking';
@@ -146,6 +148,12 @@ export type AxAIAnthropicChatRequest = {
                   data: string;
                   signature?: string;
                 }
+              | ({
+                  type: 'tool_use';
+                  id: string;
+                  name: string;
+                  input: object;
+                } & AxAIAnthropicChatRequestCacheParam)
             )[];
       }
   )[];


### PR DESCRIPTION
## Summary

Fixes prompt caching for assistant messages in the Anthropic API by placing `cache_control` on content blocks rather than on the message object itself.

## Problem

When `cache: true` was set on an assistant message, the Anthropic API returned a 400 Bad Request error. This was because the `cache_control` attribute was being placed at the message level, which Anthropic does not support.

According to Anthropic's documentation, `cache_control` must be placed on **content blocks** within messages (e.g., text blocks, tool_use blocks), not on the message object itself.

## Changes

### `src/ax/ai/anthropic/types.ts`
- Added `AxAIAnthropicChatRequestCacheParam` to `text` and `tool_use` content blocks in assistant messages, allowing these blocks to include `cache_control`

### `src/ax/ai/anthropic/api.ts`
- Added logic to handle `msg.cache` for assistant messages:
  - If content is a string, converts it to an array with a text block containing `cache_control`
  - If content is already an array, adds `cache_control` to the last text block
- This ensures the cache breakpoint is correctly placed on a content block, not the message itself