### PR TITLE
Fix/495 ollama thinking

### DIFF
--- a/src/ax/ai/mistral/api.ts
+++ b/src/ax/ai/mistral/api.ts
@@ -134,7 +134,8 @@ export class AxAIMistral<TModelKey> extends AxAIOpenAIBase<
 
     // Chat request updater to add Grok's search parameters
     const chatReqUpdater = (
-      req: Readonly<AxAIOpenAIChatRequest<AxAIMistralModel>>
+      req: Readonly<AxAIOpenAIChatRequest<AxAIMistralModel>>,
+      _options: Readonly<AxAIServiceOptions>
     ): AxAIMistralChatRequest => {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       const { max_completion_tokens, messages, ...result } =

--- a/src/ax/ai/ollama/api.test.ts
+++ b/src/ax/ai/ollama/api.test.ts
@@ -118,3 +118,70 @@ describe('AxAIOllama thinking controls', () => {
     expect('think' in capture.lastBody).toBe(false);
   });
 });
+
+describe('AxAIOllama think tag extraction (non-streaming)', () => {
+  it('extracts <think> content into thought field', async () => {
+    const ai = new AxAIOllama({
+      apiKey: 'not-set',
+      config: { model: 'qwen3:0.6b' },
+    });
+
+    const capture: { lastBody?: any } = {};
+    const fetch = createMockFetch(
+      {
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: '<think>I should say hi</think>\nHello!',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      capture
+    );
+
+    ai.setOptions({ fetch });
+
+    const res = await ai.chat(
+      { model: 'qwen3:0.6b', chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false, thinkingTokenBudget: 'low' }
+    );
+
+    expect(res.results[0]?.thought).toBe('I should say hi');
+    expect(res.results[0]?.content).toBe('Hello!');
+  });
+
+  it('leaves content unchanged when no <think> tags present', async () => {
+    const ai = new AxAIOllama({
+      apiKey: 'not-set',
+      config: { model: 'qwen3:0.6b' },
+    });
+
+    const capture: { lastBody?: any } = {};
+    const fetch = createMockFetch(
+      {
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'Hello!' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      capture
+    );
+
+    ai.setOptions({ fetch });
+
+    const res = await ai.chat(
+      { model: 'qwen3:0.6b', chatPrompt: [{ role: 'user', content: 'hi' }] },
+      { stream: false }
+    );
+
+    expect(res.results[0]?.thought).toBeUndefined();
+    expect(res.results[0]?.content).toBe('Hello!');
+  });
+});

--- a/src/ax/ai/ollama/api.test.ts
+++ b/src/ax/ai/ollama/api.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AxAIOllama } from './api.js';
+
+function createMockFetch(body: unknown, capture: { lastBody?: any }) {
+  return vi
+    .fn()
+    .mockImplementation(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      try {
+        if (init?.body && typeof init.body === 'string') {
+          capture.lastBody = JSON.parse(init.body);
+        }
+      } catch {}
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+}
+
+describe('AxAIOllama thinking controls', () => {
+  it('passes thinkingTokenBudget none through as think false', async () => {
+    const ai = new AxAIOllama({
+      apiKey: 'not-set',
+      config: { model: 'qwen3.5:0.8b' },
+    });
+
+    const capture: { lastBody?: any } = {};
+    const fetch = createMockFetch(
+      {
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      capture
+    );
+
+    ai.setOptions({ fetch });
+
+    const res = await ai.chat(
+      {
+        model: 'qwen3.5:0.8b',
+        chatPrompt: [{ role: 'user', content: 'hi' }],
+      },
+      { stream: false, thinkingTokenBudget: 'none' }
+    );
+
+    expect(res.results[0]?.content).toBe('ok');
+    expect(fetch).toHaveBeenCalled();
+    expect(capture.lastBody.think).toBe(false);
+  });
+
+  it('passes non-none thinkingTokenBudget through as think true', async () => {
+    const ai = new AxAIOllama({
+      apiKey: 'not-set',
+      config: { model: 'qwen3:0.6b' },
+    });
+
+    const capture: { lastBody?: any } = {};
+    const fetch = createMockFetch(
+      {
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      capture
+    );
+
+    ai.setOptions({ fetch });
+
+    await ai.chat(
+      {
+        model: 'qwen3:0.6b',
+        chatPrompt: [{ role: 'user', content: 'hi' }],
+      },
+      { stream: false, thinkingTokenBudget: 'low' }
+    );
+
+    expect(fetch).toHaveBeenCalled();
+    expect(capture.lastBody.think).toBe(true);
+  });
+
+  it('does not add think when no thinkingTokenBudget is provided', async () => {
+    const ai = new AxAIOllama({
+      apiKey: 'not-set',
+      config: { model: 'qwen3:0.6b' },
+    });
+
+    const capture: { lastBody?: any } = {};
+    const fetch = createMockFetch(
+      {
+        choices: [
+          {
+            index: 0,
+            message: { role: 'assistant', content: 'ok' },
+            finish_reason: 'stop',
+          },
+        ],
+      },
+      capture
+    );
+
+    ai.setOptions({ fetch });
+
+    await ai.chat({
+      model: 'qwen3:0.6b',
+      chatPrompt: [{ role: 'user', content: 'hi' }],
+    });
+
+    expect(fetch).toHaveBeenCalled();
+    expect('think' in capture.lastBody).toBe(false);
+  });
+});

--- a/src/ax/ai/ollama/api.ts
+++ b/src/ax/ai/ollama/api.ts
@@ -3,12 +3,20 @@ import {
   axBaseAIDefaultCreativeConfig,
 } from '../base.js';
 import { type AxAIOpenAIArgs, AxAIOpenAIBase } from '../openai/api.js';
-import type { AxAIOpenAIConfig } from '../openai/chat_types.js';
+import type {
+  AxAIOpenAIChatRequest,
+  AxAIOpenAIConfig,
+} from '../openai/chat_types.js';
+import type { AxAIServiceOptions } from '../types.js';
 
 /**
  * Configuration type for Ollama AI service
  */
 export type AxAIOllamaAIConfig = AxAIOpenAIConfig<string, string>;
+
+type AxAIOllamaChatRequest = AxAIOpenAIChatRequest<string> & {
+  think?: boolean;
+};
 
 /**
  * Creates default configuration for Ollama AI service
@@ -55,7 +63,8 @@ export type AxAIOllamaArgs<TModelKey> = AxAIOpenAIArgs<
 export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
   string,
   string,
-  TModelKey
+  TModelKey,
+  AxAIOllamaChatRequest
 > {
   /**
    * Creates a new Ollama AI service instance
@@ -77,6 +86,21 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       ...axAIOllamaDefaultConfig(),
       ...config,
     };
+
+    const chatReqUpdater = (
+      req: Readonly<AxAIOllamaChatRequest>,
+      serviceOptions: Readonly<AxAIServiceOptions>
+    ): AxAIOllamaChatRequest => {
+      if (!serviceOptions.thinkingTokenBudget) {
+        return req;
+      }
+
+      return {
+        ...req,
+        think: serviceOptions.thinkingTokenBudget !== 'none',
+      };
+    };
+
     super({
       apiKey,
       options,
@@ -84,10 +108,11 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       apiURL: url,
       models,
       modelInfo: [],
+      chatReqUpdater,
       supportFor: {
         functions: true,
         streaming: true,
-        hasThinkingBudget: false,
+        hasThinkingBudget: true,
         hasShowThoughts: false,
         media: {
           images: {
@@ -113,7 +138,7 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
           supported: false,
           types: [],
         },
-        thinking: false,
+        thinking: true,
         multiTurn: true,
       },
     });

--- a/src/ax/ai/ollama/api.ts
+++ b/src/ax/ai/ollama/api.ts
@@ -7,7 +7,71 @@ import type {
   AxAIOpenAIChatRequest,
   AxAIOpenAIConfig,
 } from '../openai/chat_types.js';
+import type { AxChatResponse } from '../types.js';
 import type { AxAIServiceOptions } from '../types.js';
+
+/**
+ * Extracts <think>...</think> content from a full (non-streaming) response.
+ * Returns thought and cleaned content separately.
+ */
+function extractThinkTags(content: string): {
+  thought?: string;
+  content?: string;
+} {
+  const match = content.match(/^<think>([\s\S]*?)<\/think>\n?([\s\S]*)$/);
+  if (!match) return { content };
+  return {
+    thought: match[1] || undefined,
+    content: match[2] || undefined,
+  };
+}
+
+type OllamaThinkStreamState = {
+  ollamaInThink?: boolean;
+};
+
+/**
+ * Processes a streaming chunk, routing <think>...</think> content to the
+ * `thought` field and leaving the rest in `content`.
+ */
+function processThinkStreamChunk(
+  content: string | undefined,
+  state: OllamaThinkStreamState
+): { content?: string; thought?: string } {
+  if (!content) return {};
+
+  if (!state.ollamaInThink && !content.includes('<think>')) {
+    return { content };
+  }
+
+  let remaining = content;
+  let thoughtOut = '';
+  let contentOut = '';
+
+  if (!state.ollamaInThink && remaining.includes('<think>')) {
+    const idx = remaining.indexOf('<think>');
+    contentOut += remaining.slice(0, idx);
+    remaining = remaining.slice(idx + '<think>'.length);
+    state.ollamaInThink = true;
+  }
+
+  if (state.ollamaInThink) {
+    if (remaining.includes('</think>')) {
+      const idx = remaining.indexOf('</think>');
+      thoughtOut += remaining.slice(0, idx);
+      remaining = remaining.slice(idx + '</think>'.length).replace(/^\n/, '');
+      state.ollamaInThink = false;
+      contentOut += remaining;
+    } else {
+      thoughtOut += remaining;
+    }
+  }
+
+  return {
+    content: contentOut || undefined,
+    thought: thoughtOut || undefined,
+  };
+}
 
 /**
  * Configuration type for Ollama AI service
@@ -101,6 +165,33 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       };
     };
 
+    const chatRespProcessor = (resp: AxChatResponse): AxChatResponse => ({
+      ...resp,
+      results: resp.results.map((result) => {
+        if (!result.content) return result;
+        const extracted = extractThinkTags(result.content);
+        return {
+          ...result,
+          thought: extracted.thought ?? result.thought,
+          content: extracted.content,
+        };
+      }),
+    });
+
+    const chatStreamRespProcessor = (
+      resp: AxChatResponse,
+      state: object
+    ): AxChatResponse => ({
+      ...resp,
+      results: resp.results.map((result) => {
+        const { content, thought } = processThinkStreamChunk(
+          result.content,
+          state as OllamaThinkStreamState
+        );
+        return { ...result, content, thought: thought ?? result.thought };
+      }),
+    });
+
     super({
       apiKey,
       options,
@@ -109,11 +200,13 @@ export class AxAIOllama<TModelKey> extends AxAIOpenAIBase<
       models,
       modelInfo: [],
       chatReqUpdater,
+      chatRespProcessor,
+      chatStreamRespProcessor,
       supportFor: {
         functions: true,
         streaming: true,
         hasThinkingBudget: true,
-        hasShowThoughts: false,
+        hasShowThoughts: true,
         media: {
           images: {
             supported: false,

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -109,7 +109,8 @@ export interface AxAIOpenAIArgs<
 }
 
 type ChatReqUpdater<TModel, TChatReq extends AxAIOpenAIChatRequest<TModel>> = (
-  req: Readonly<TChatReq>
+  req: Readonly<TChatReq>,
+  config: Readonly<AxAIServiceOptions>
 ) => TChatReq;
 
 export interface AxAIOpenAIBaseArgs<
@@ -359,7 +360,7 @@ class AxAIOpenAIImpl<
     }
 
     if (this.chatReqUpdater) {
-      reqValue = this.chatReqUpdater(reqValue as TChatReq);
+      reqValue = this.chatReqUpdater(reqValue as TChatReq, config);
     }
 
     return [apiConfig, reqValue];

--- a/src/ax/ai/openai/api.ts
+++ b/src/ax/ai/openai/api.ts
@@ -113,6 +113,12 @@ type ChatReqUpdater<TModel, TChatReq extends AxAIOpenAIChatRequest<TModel>> = (
   config: Readonly<AxAIServiceOptions>
 ) => TChatReq;
 
+type ChatRespProcessor = (resp: AxChatResponse) => AxChatResponse;
+type ChatStreamRespProcessor = (
+  resp: AxChatResponse,
+  state: object
+) => AxChatResponse;
+
 export interface AxAIOpenAIBaseArgs<
   TModel,
   TEmbedModel,
@@ -126,6 +132,8 @@ export interface AxAIOpenAIBaseArgs<
   modelInfo: Readonly<AxModelInfo[]>;
   models?: AxAIInputModelList<TModel, TEmbedModel, TModelKey>;
   chatReqUpdater?: ChatReqUpdater<TModel, TChatReq>;
+  chatRespProcessor?: ChatRespProcessor;
+  chatStreamRespProcessor?: ChatStreamRespProcessor;
   supportFor: AxAIFeatures | ((model: TModel) => AxAIFeatures);
 }
 
@@ -149,7 +157,9 @@ class AxAIOpenAIImpl<
   constructor(
     private readonly config: Readonly<AxAIOpenAIConfig<TModel, TEmbedModel>>,
     private streamingUsage: boolean,
-    private readonly chatReqUpdater?: ChatReqUpdater<TModel, TChatReq>
+    private readonly chatReqUpdater?: ChatReqUpdater<TModel, TChatReq>,
+    private readonly chatRespProcessor?: ChatRespProcessor,
+    private readonly chatStreamRespProcessor?: ChatStreamRespProcessor
   ) {}
 
   getTokenUsage(): AxTokenUsage | undefined {
@@ -439,10 +449,8 @@ class AxAIOpenAIImpl<
       };
     });
 
-    return {
-      results,
-      remoteId: id,
-    };
+    const chatResp: AxChatResponse = { results, remoteId: id };
+    return this.chatRespProcessor ? this.chatRespProcessor(chatResp) : chatResp;
   }
 
   createChatStreamResp = (
@@ -531,7 +539,10 @@ class AxAIOpenAIImpl<
       }
     );
 
-    return { results };
+    const chatStreamResp: AxChatResponse = { results };
+    return this.chatStreamRespProcessor
+      ? this.chatStreamRespProcessor(chatStreamResp, state)
+      : chatStreamResp;
   };
 
   createEmbedResp(resp: Readonly<AxAIOpenAIEmbedResponse>): AxEmbedResponse {
@@ -684,6 +695,8 @@ export class AxAIOpenAIBase<
     modelInfo,
     models,
     chatReqUpdater,
+    chatRespProcessor,
+    chatStreamRespProcessor,
     supportFor,
   }: Readonly<
     Omit<AxAIOpenAIBaseArgs<TModel, TEmbedModel, TModelKey, TChatReq>, 'name'>
@@ -695,7 +708,9 @@ export class AxAIOpenAIBase<
     const aiImpl = new AxAIOpenAIImpl<TModel, TEmbedModel, TChatReq>(
       config,
       options?.streamingUsage ?? true,
-      chatReqUpdater
+      chatReqUpdater,
+      chatRespProcessor,
+      chatStreamRespProcessor
     );
 
     super(aiImpl, {

--- a/src/ax/ai/x-grok/api.ts
+++ b/src/ax/ai/x-grok/api.ts
@@ -137,7 +137,10 @@ export class AxAIGrok<TModelKey> extends AxAIOpenAIBase<
     };
 
     // Chat request updater to add Grok's search parameters
-    const chatReqUpdater = (req: AxAIGrokChatRequest): AxAIGrokChatRequest => {
+    const chatReqUpdater = (
+      req: AxAIGrokChatRequest,
+      _options: Readonly<AxAIServiceOptions>
+    ): AxAIGrokChatRequest => {
       if (options?.searchParameters) {
         const searchParams = options.searchParameters;
         return {


### PR DESCRIPTION
  Closes #495

  ## Changes

  ### New: `chatRespProcessor` / `chatStreamRespProcessor` callbacks
  Added two optional callbacks to `AxAIOpenAIBaseArgs` (following the existing `chatReqUpdater` pattern), allowing providers to post-process responses without subclassing
  `AxAIOpenAIImpl`.

  ### Ollama think parameter support
  - `thinkingTokenBudget: 'none'` → sends `think: false` (disables thinking, reduces latency)
  - Any other budget value → sends `think: true`
  - `hasThinkingBudget` and `hasShowThoughts` both set to `true`

  ### `<think>` tag extraction
  When Ollama returns thinking content inline as `<think>...</think>`, it is now extracted into the `thought` field and removed from `content`:
  - Non-streaming: regex extraction after full response
  - Streaming: stateful chunk-by-chunk routing via `processThinkStreamChunk()`

  ## Testing
  - `test:unit`: 1854 passed
  - `test:type-check`: clean
  - `test:lint`: clean