### PR TITLE
fix(agent): extract code from anywhere in javascriptCode field

### DIFF
--- a/src/ax/prompts/agent/AxAgent.ts
+++ b/src/ax/prompts/agent/AxAgent.ts
@@ -1863,7 +1863,9 @@ export class AxAgent<IN extends AxGenIn, OUT extends AxGenOut>
 
     actorSigBuilder = actorSigBuilder.output(
       'javascriptCode',
-      f.code('JavaScript code to execute in runtime session')
+      f.code(
+        'Pure raw JavaScript code only. No markdown backticks, no code fences, no prose, no <think> tags. Single statement ending in console.log().'
+      )
     ) as any;
 
     if (actorOutputFields.length > 0) {

--- a/src/ax/prompts/agent/optimize.test.ts
+++ b/src/ax/prompts/agent/optimize.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeActorJavascriptCode } from './optimize.js';
+
+describe('normalizeActorJavascriptCode', () => {
+  it('passes through plain code unchanged', () => {
+    const code = `const x = 1;\nconsole.log(x);`;
+    expect(normalizeActorJavascriptCode(code)).toBe(code);
+  });
+
+  it('strips ```javascript fences at the exact boundaries', () => {
+    const fenced = '```javascript\nconst x = 1;\nconsole.log(x);\n```';
+    expect(normalizeActorJavascriptCode(fenced)).toBe(
+      `const x = 1;\nconsole.log(x);`
+    );
+  });
+
+  it('strips bare ``` fences without a language tag', () => {
+    const fenced = '```\nconst x = 1;\nconsole.log(x);\n```';
+    expect(normalizeActorJavascriptCode(fenced)).toBe(
+      `const x = 1;\nconsole.log(x);`
+    );
+  });
+
+  it('extracts the inner code when the model prefixes prose before the fence', () => {
+    const noisy = `Looking at the previous result, the query returned individual records. I need to use the proper aggregation:
+\`\`\`javascript
+const result = await data.query('{ orders { count_id sum_total } }');
+console.log(result);
+\`\`\``;
+    expect(normalizeActorJavascriptCode(noisy)).toBe(
+      `const result = await data.query('{ orders { count_id sum_total } }');\nconsole.log(result);`
+    );
+  });
+
+  it('removes paired <think>...</think> reasoning blocks', () => {
+    const withThink = `<think>Let me reason about this step by step.</think>const x = 1;\nconsole.log(x);`;
+    expect(normalizeActorJavascriptCode(withThink)).toBe(
+      `const x = 1;\nconsole.log(x);`
+    );
+  });
+
+  it('removes orphan </think> closers without a matching opener', () => {
+    const orphan = `Some leaked reasoning</think>const x = 1;\nconsole.log(x);`;
+    expect(normalizeActorJavascriptCode(orphan)).toBe(
+      `const x = 1;\nconsole.log(x);`
+    );
+  });
+
+  it('handles prose + </think> + fenced code combined', () => {
+    const ugly = `I will now run the query:</think>\`\`\`javascript
+const result = await data.query('{ users(limit: 1) { count_id } }');
+console.log(result);
+\`\`\``;
+    expect(normalizeActorJavascriptCode(ugly)).toBe(
+      `const result = await data.query('{ users(limit: 1) { count_id } }');\nconsole.log(result);`
+    );
+  });
+
+  it('extracts the first fenced block when multiple are present', () => {
+    const multi = `First attempt:
+\`\`\`javascript
+const a = 1;
+console.log(a);
+\`\`\`
+Second attempt:
+\`\`\`javascript
+const b = 2;
+console.log(b);
+\`\`\``;
+    expect(normalizeActorJavascriptCode(multi)).toBe(
+      `const a = 1;\nconsole.log(a);`
+    );
+  });
+
+  it('returns the input as-is when there are no fences and no think tags', () => {
+    const code = `const result = await data.query('{ orders { count_id } }');\nconsole.log(result);`;
+    expect(normalizeActorJavascriptCode(code)).toBe(code);
+  });
+});

--- a/src/ax/prompts/agent/optimize.ts
+++ b/src/ax/prompts/agent/optimize.ts
@@ -257,6 +257,26 @@ export function serializeForEval(value: unknown): AxFieldValue {
 export function normalizeActorJavascriptCode(code: string): string {
   let normalized = code.trim();
 
+  // Strip <think>...</think> reasoning blocks (some models leak them into
+  // structured output fields).
+  normalized = normalized.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+  // And orphan </think> closers, dropping any prose preceding them on the
+  // same line — that prose is the reasoning that wasn't wrapped in a
+  // matching opener.
+  normalized = normalized.replace(/[^\n]*<\/think>/g, '').trim();
+
+  // If the value contains a fenced code block anywhere (not necessarily at the
+  // exact start/end), extract the *first* fenced block's contents. This handles
+  // models that prefix their javascriptCode with prose / reasoning before the
+  // ```javascript fence (e.g. GLM-5).
+  const fencedBlock = normalized.match(
+    /```(?:[A-Za-z0-9_-]+)?[ \t]*\r?\n([\s\S]*?)\r?\n?```/
+  );
+  if (fencedBlock?.[1] !== undefined) {
+    normalized = fencedBlock[1].trim();
+  }
+
+  // Then run the original loop to clean up any remaining edge fences.
   for (;;) {
     const before = normalized;
 


### PR DESCRIPTION
## Summary

`normalizeActorJavascriptCode` previously only stripped ``` ` ``` ` ``` fences when they sat at the *exact* start/end of the trimmed value. Some models — notably **GLM-5** on Vertex MaaS — prefix their `javascriptCode` field with reasoning prose or a stray `</think>` tag before the ` ```javascript ` fence, which left the fence in place. The actor's policy validator then couldn't find `console.log` past the fence and rejected every turn with `[POLICY] Non-final turns must include at least one console.log(...)`.

This PR makes the normalizer tolerant of common malformed-but-recoverable shapes:

1. Strip paired `<think>...</think>` reasoning blocks anywhere in the value.
2. Strip orphan `</think>` closers, dropping any same-line prose that preceded them (that prose was the leaked reasoning).
3. If a fenced code block appears anywhere (not just at the boundaries), extract the contents of the **first** such block. Handles `prose then fence` layouts.
4. Then run the original boundary-fence loop as a final cleanup pass.

Also strengthens the field description on the actor's `javascriptCode` output:

\`\`\`diff
- f.code('JavaScript code to execute in runtime session')
+ f.code(
+   'Pure raw JavaScript code only. No markdown backticks, no code fences, no prose, no <think> tags. Single statement ending in console.log().'
+ )
\`\`\`

The original description gave models no signal that markdown wrapping would break execution.

## Real-world motivation

Hit while running an `AxAgent` RLM workflow with `zai-org/glm-5-maas` via Vertex AI's OpenAI-compat MaaS endpoint. GLM-5 reliably wraps actor JS in ` ```javascript ... ``` ` fences (and occasionally leaks `<think>` tags), and 19 out of 20 actor turns failed before any data probe could run. With this patch, the same agent runs end-to-end against the same model with no client-side wrappers.

## Test plan

- [x] Added \`src/ax/prompts/agent/optimize.test.ts\` with 9 cases covering plain code, language-tagged fences, bare fences, prose-prefixed fences, paired and orphan think tags, and multi-fence inputs.
- [x] \`npx vitest run prompts/agent/optimize.test.ts\` — 9/9 pass.
- [x] \`npx biome check\` clean on the touched files.
- [x] Verified end-to-end against GLM-5 in a real RLM agent run after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)