### PR TITLE
fix(metrics): use shared model name normalization for cost and config lookups

### DIFF
--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -871,7 +871,10 @@ export class AxBaseAI<
     if (!modelUsage?.tokens?.promptTokens) return 0;
 
     // Get model info to find context window size
-    const modelInfo = getModelInfo({ model: model as string, modelInfo: this.modelInfo });
+    const modelInfo = getModelInfo({
+      model: model as string,
+      modelInfo: this.modelInfo,
+    });
     if (!modelInfo?.contextWindow) return 0;
 
     return modelUsage.tokens.promptTokens / modelInfo.contextWindow;
@@ -885,7 +888,10 @@ export class AxBaseAI<
     if (!modelUsage?.tokens) return 0;
 
     // Get model info to find pricing
-    const modelInfo = getModelInfo({ model: modelName, modelInfo: this.modelInfo });
+    const modelInfo = getModelInfo({
+      model: modelName,
+      modelInfo: this.modelInfo,
+    });
     if (
       !modelInfo ||
       (!modelInfo.promptTokenCostPer1M && !modelInfo.completionTokenCostPer1M)
@@ -1291,7 +1297,10 @@ export class AxBaseAI<
       ...req.modelConfig,
     } as AxModelConfig;
 
-    const selectedModelInfo = getModelInfo({ model: model as string, modelInfo: this.modelInfo });
+    const selectedModelInfo = getModelInfo({
+      model: model as string,
+      modelInfo: this.modelInfo,
+    });
     if (selectedModelInfo?.notSupported?.temperature) {
       if ('temperature' in modelConfig) {
         delete (modelConfig as { temperature?: number }).temperature;
@@ -1304,7 +1313,10 @@ export class AxBaseAI<
     }
 
     // Check for expensive model usage
-    if (selectedModelInfo?.isExpensive && options?.useExpensiveModel !== 'yes') {
+    if (
+      selectedModelInfo?.isExpensive &&
+      options?.useExpensiveModel !== 'yes'
+    ) {
       throw new Error(
         `Model ${model as string} is marked as expensive and requires explicit confirmation. Set useExpensiveModel: "yes" to proceed.`
       );

--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -1,6 +1,7 @@
 import { context, type Span, SpanKind } from '@opentelemetry/api';
 import { axGlobals } from '../dsp/globals.js';
 import { defaultLogger } from '../dsp/loggers.js';
+import { getModelInfo } from '../dsp/modelinfo.js';
 import type { AxMessage } from '../dsp/types.js';
 import { axSpanAttributes, axSpanEvents } from '../trace/trace.js';
 import { apiCall } from '../util/apicall.js';
@@ -870,9 +871,7 @@ export class AxBaseAI<
     if (!modelUsage?.tokens?.promptTokens) return 0;
 
     // Get model info to find context window size
-    const modelInfo = this.modelInfo.find(
-      (info) => info.name === (model as string)
-    );
+    const modelInfo = getModelInfo({ model: model as string, modelInfo: this.modelInfo });
     if (!modelInfo?.contextWindow) return 0;
 
     return modelUsage.tokens.promptTokens / modelInfo.contextWindow;
@@ -886,7 +885,7 @@ export class AxBaseAI<
     if (!modelUsage?.tokens) return 0;
 
     // Get model info to find pricing
-    const modelInfo = this.modelInfo.find((info) => info.name === modelName);
+    const modelInfo = getModelInfo({ model: modelName, modelInfo: this.modelInfo });
     if (
       !modelInfo ||
       (!modelInfo.promptTokenCostPer1M && !modelInfo.completionTokenCostPer1M)
@@ -1292,9 +1291,7 @@ export class AxBaseAI<
       ...req.modelConfig,
     } as AxModelConfig;
 
-    const selectedModelInfo = this.modelInfo.find(
-      (info) => info.name === (model as string)
-    );
+    const selectedModelInfo = getModelInfo({ model: model as string, modelInfo: this.modelInfo });
     if (selectedModelInfo?.notSupported?.temperature) {
       if ('temperature' in modelConfig) {
         delete (modelConfig as { temperature?: number }).temperature;
@@ -1307,10 +1304,7 @@ export class AxBaseAI<
     }
 
     // Check for expensive model usage
-    const modelInfo = this.modelInfo.find(
-      (info) => info.name === (model as string)
-    );
-    if (modelInfo?.isExpensive && options?.useExpensiveModel !== 'yes') {
+    if (selectedModelInfo?.isExpensive && options?.useExpensiveModel !== 'yes') {
       throw new Error(
         `Model ${model as string} is marked as expensive and requires explicit confirmation. Set useExpensiveModel: "yes" to proceed.`
       );


### PR DESCRIPTION
- **What kind of change does this PR introduce?** Bug fix

- **What is the current behavior?**

`AxBaseAI` performs model info lookups (for cost estimation, context window tracking, feature support, and expensive-model checks) using exact string matching against the model info catalog. When a model is identified by a dated or suffixed variant — e.g., `claude-haiku-4-5-20251001`, `claude-opus-4-5@20251101`, or `gpt-4o-mini-8388383` — the exact match fails silently. This causes:

- Cost estimation returning 0, so `recordEstimatedCostMetric` is never called
- Context window usage always reporting 0
- Feature-support and expensive-model guards being bypassed

The repo already has a well-tested `getModelInfo()` in `src/ax/dsp/modelinfo.ts` that handles normalization (stripping date suffixes, vendor prefixes, version tags, etc.), but `AxBaseAI` was not using it.

- **What is the new behavior (if this is a feature change)?**

All four model info lookup sites in `AxBaseAI` now delegate to the shared `getModelInfo()`, so dated and suffixed model IDs resolve correctly to their catalog entry. Cost metrics, context window tracking, and config guards work for all model name variants that `getModelInfo` already supports.

Also removed a redundant duplicate lookup — the expensive-model check now reuses `selectedModelInfo` instead of performing a separate find on the same model.

- **Other information**:

The change is 5 insertions and 11 deletions, entirely within `src/ax/ai/base.ts`. All 1877 existing tests pass with no changes needed.