### PR TITLE
fix: normalize OpenAI Responses cached token usage

### DIFF
--- a/src/ax/ai/openai/responses_api.ts
+++ b/src/ax/ai/openai/responses_api.ts
@@ -535,9 +535,12 @@ export class AxAIOpenAIResponsesImpl<
 
     if (usage) {
       this.tokensUsed = {
-        promptTokens: usage.prompt_tokens,
+        promptTokens: usage.prompt_tokens ?? usage.input_tokens ?? 0,
         completionTokens: usage.completion_tokens ?? usage.output_tokens ?? 0,
         totalTokens: usage.total_tokens,
+        cacheReadTokens:
+          usage.prompt_tokens_details?.cached_tokens ??
+          usage.input_tokens_details?.cached_tokens,
       };
     }
 
@@ -1106,12 +1109,18 @@ export class AxAIOpenAIResponsesImpl<
         // Response completion - handle usage
         if (event.response.usage) {
           this.tokensUsed = {
-            promptTokens: event.response.usage.prompt_tokens,
+            promptTokens:
+              event.response.usage.prompt_tokens ??
+              event.response.usage.input_tokens ??
+              0,
             completionTokens:
               event.response.usage.completion_tokens ??
               event.response.usage.output_tokens ??
               0,
             totalTokens: event.response.usage.total_tokens,
+            cacheReadTokens:
+              event.response.usage.prompt_tokens_details?.cached_tokens ??
+              event.response.usage.input_tokens_details?.cached_tokens,
           };
         }
         remoteId = event.response.id;

--- a/src/ax/ai/openai/responses_api.usage.test.ts
+++ b/src/ax/ai/openai/responses_api.usage.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { AxAIOpenAIResponsesImpl } from './responses_api.js';
+import type {
+  AxAIOpenAIResponsesResponse,
+  AxAIOpenAIResponsesResponseDelta,
+} from './responses_types.js';
+
+const config = {
+  maxTokens: 1,
+  stream: false,
+} as unknown as Parameters<
+  ConstructorParameters<typeof AxAIOpenAIResponsesImpl>[0]
+>[0];
+
+describe('OpenAI Responses cached token usage', () => {
+  it('maps non-streaming input_tokens_details.cached_tokens to cacheReadTokens', () => {
+    const impl = new AxAIOpenAIResponsesImpl(config, true);
+
+    const resp = {
+      id: 'res1',
+      output: [
+        {
+          type: 'message',
+          id: 'msg1',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'cached reply' }],
+        },
+      ],
+      usage: {
+        input_tokens: 2006,
+        output_tokens: 300,
+        total_tokens: 2306,
+        input_tokens_details: {
+          cached_tokens: 1920,
+        },
+      },
+    } as unknown as AxAIOpenAIResponsesResponse;
+
+    impl.createChatResp(resp);
+
+    expect(impl.getTokenUsage()).toEqual({
+      promptTokens: 2006,
+      completionTokens: 300,
+      totalTokens: 2306,
+      cacheReadTokens: 1920,
+    });
+  });
+
+  it('maps streaming response.completed input cached tokens to cacheReadTokens', () => {
+    const impl = new AxAIOpenAIResponsesImpl(config, true);
+
+    const event = {
+      type: 'response.completed',
+      response: {
+        id: 'res2',
+        usage: {
+          input_tokens: 1500,
+          output_tokens: 120,
+          total_tokens: 1620,
+          input_tokens_details: {
+            cached_tokens: 1024,
+          },
+        },
+      },
+    } as unknown as AxAIOpenAIResponsesResponseDelta;
+
+    impl.createChatStreamResp(event);
+
+    expect(impl.getTokenUsage()).toEqual({
+      promptTokens: 1500,
+      completionTokens: 120,
+      totalTokens: 1620,
+      cacheReadTokens: 1024,
+    });
+  });
+});

--- a/src/ax/ai/openai/responses_types.ts
+++ b/src/ax/ai/openai/responses_types.ts
@@ -299,10 +299,17 @@ export interface AxAIOpenAIResponsesResponse {
   readonly model: string; // Model ID used
   readonly output: ReadonlyArray<AxAIOpenAIResponsesOutputItem>;
   readonly usage?: {
-    readonly prompt_tokens: number;
+    readonly prompt_tokens?: number;
+    readonly input_tokens?: number;
     readonly completion_tokens?: number; // Some variants use output_tokens
     readonly output_tokens?: number; // Alias seen in some responses
     readonly total_tokens: number;
+    readonly prompt_tokens_details?: {
+      readonly cached_tokens?: number;
+    };
+    readonly input_tokens_details?: {
+      readonly cached_tokens?: number;
+    };
     // reasoning_tokens?: number // if applicable and included
   } | null;
 }
@@ -737,9 +744,17 @@ export interface AxAIOpenAIResponsesResponseDelta {
   // If event is 'response.done'
   readonly response?: Readonly<AxAIOpenAIResponsesResponse>; // The final full response object (often without items if streamed separately)
   readonly usage?: {
-    readonly prompt_tokens: number;
-    readonly completion_tokens: number;
+    readonly prompt_tokens?: number;
+    readonly input_tokens?: number;
+    readonly completion_tokens?: number; // Some variants use output_tokens
+    readonly output_tokens?: number; // Alias seen in some responses
     readonly total_tokens: number;
+    readonly prompt_tokens_details?: {
+      readonly cached_tokens?: number;
+    };
+    readonly input_tokens_details?: {
+      readonly cached_tokens?: number;
+    };
     // reasoning_tokens?: number
   } | null; // Usage often comes in the 'response.done' event or with stream_options
 }


### PR DESCRIPTION
## Summary
- normalize OpenAI Responses usage parsing across both legacy `prompt_tokens*` and current `input_tokens*` payloads
- map cached prompt token hits to `cacheReadTokens` for non-streaming and streaming completion paths
- add focused adapter tests for cached token normalization

## Testing
- `npm exec vitest run ai/openai/responses_api.usage.test.ts ai/openai/responses_api.citations.test.ts`

