### PR TITLE
fix(google-gemini): correct Vertex cachedContents URL and model resource

### DIFF
--- a/src/ax/ai/base.ts
+++ b/src/ax/ai/base.ts
@@ -2047,9 +2047,7 @@ export class AxBaseAI<
         await this.executeCacheOperation(
           this.aiImpl.buildCacheUpdateTTLOp(
             existingEntry.cacheName,
-            ttlSeconds,
-            req.model,
-            options?.beta
+            ttlSeconds
           ),
           options,
           span

--- a/src/ax/ai/google-gemini/api.test.ts
+++ b/src/ax/ai/google-gemini/api.test.ts
@@ -1637,7 +1637,7 @@ describe('AxAIGoogleGemini model key preset merging', () => {
       );
     });
 
-    it('routes global Vertex cache creation to the v1beta1 endpoint without a region prefix', async () => {
+    it('routes global Vertex cache creation to the v1 endpoint without a region prefix', async () => {
       const ai = new AxAIGoogleGemini({
         apiKey: async () => 'vertex-token',
         projectId: 'demo-project',
@@ -1680,7 +1680,7 @@ describe('AxAIGoogleGemini model key preset merging', () => {
       expect(capture.calls).toHaveLength(2);
 
       expect(capture.calls[0]?.url).toBe(
-        'https://aiplatform.googleapis.com/v1beta1/projects/demo-project/locations/global/cachedContents'
+        'https://aiplatform.googleapis.com/v1/projects/demo-project/locations/global/cachedContents'
       );
 
       const cacheCreateReq = capture.calls[0]?.body;

--- a/src/ax/ai/google-gemini/api.test.ts
+++ b/src/ax/ai/google-gemini/api.test.ts
@@ -1545,6 +1545,151 @@ describe('AxAIGoogleGemini model key preset merging', () => {
     });
   });
 
+  describe('Vertex context caching URL composition', () => {
+    const cacheCreateResponse = {
+      name: 'projects/demo-project/locations/us-central1/cachedContents/abc123',
+      expireTime: '2099-01-01T00:00:00Z',
+      usageMetadata: { totalTokenCount: 4096 },
+    };
+
+    const generateResponse = {
+      candidates: [
+        {
+          content: { parts: [{ text: 'ok' }] },
+          finishReason: 'STOP',
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 16,
+        candidatesTokenCount: 4,
+        totalTokenCount: 20,
+        cachedContentTokenCount: 8,
+        thoughtsTokenCount: 0,
+      },
+    };
+
+    const createRegistry = () => {
+      const map = new Map<string, any>();
+      return {
+        registry: {
+          get: vi.fn(async (key: string) => map.get(key)),
+          set: vi.fn(async (key: string, value: unknown) => {
+            map.set(key, value);
+          }),
+        },
+      };
+    };
+
+    it('routes regional Vertex cache creation to the v1 cachedContents endpoint with a full model resource', async () => {
+      const ai = new AxAIGoogleGemini({
+        apiKey: async () => 'vertex-token',
+        projectId: 'demo-project',
+        region: 'us-central1',
+        config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+        models: [],
+      });
+
+      const capture = { calls: [] as Array<{ url: string; body?: any }> };
+      const fetch = createSequencedMockFetch(
+        [
+          {
+            ...cacheCreateResponse,
+            name: 'projects/demo-project/locations/us-central1/cachedContents/abc123',
+          },
+          generateResponse,
+        ],
+        capture
+      );
+      const { registry } = createRegistry();
+
+      ai.setOptions({ fetch });
+
+      await ai.chat(
+        {
+          chatPrompt: [
+            { role: 'system', content: 'You are a router', cache: true },
+            { role: 'user', content: 'route this request' },
+          ],
+        },
+        {
+          stream: false,
+          contextCache: {
+            minTokens: 0,
+            registry,
+          },
+        }
+      );
+
+      expect(capture.calls).toHaveLength(2);
+
+      expect(capture.calls[0]?.url).toBe(
+        'https://us-central1-aiplatform.googleapis.com/v1/projects/demo-project/locations/us-central1/cachedContents'
+      );
+
+      const cacheCreateReq = capture.calls[0]?.body;
+      expect(cacheCreateReq.model).toBe(
+        `projects/demo-project/locations/us-central1/publishers/google/models/${AxAIGoogleGeminiModel.Gemini25Flash}`
+      );
+
+      const generateReq = capture.calls[1]?.body;
+      expect(generateReq.cachedContent).toBe(
+        'projects/demo-project/locations/us-central1/cachedContents/abc123'
+      );
+    });
+
+    it('routes global Vertex cache creation to the v1beta1 endpoint without a region prefix', async () => {
+      const ai = new AxAIGoogleGemini({
+        apiKey: async () => 'vertex-token',
+        projectId: 'demo-project',
+        region: 'global',
+        config: { model: AxAIGoogleGeminiModel.Gemini25Flash },
+        models: [],
+      });
+
+      const capture = { calls: [] as Array<{ url: string; body?: any }> };
+      const fetch = createSequencedMockFetch(
+        [
+          {
+            ...cacheCreateResponse,
+            name: 'projects/demo-project/locations/global/cachedContents/abc123',
+          },
+          generateResponse,
+        ],
+        capture
+      );
+      const { registry } = createRegistry();
+
+      ai.setOptions({ fetch });
+
+      await ai.chat(
+        {
+          chatPrompt: [
+            { role: 'system', content: 'You are a router', cache: true },
+            { role: 'user', content: 'route this request' },
+          ],
+        },
+        {
+          stream: false,
+          contextCache: {
+            minTokens: 0,
+            registry,
+          },
+        }
+      );
+
+      expect(capture.calls).toHaveLength(2);
+
+      expect(capture.calls[0]?.url).toBe(
+        'https://aiplatform.googleapis.com/v1beta1/projects/demo-project/locations/global/cachedContents'
+      );
+
+      const cacheCreateReq = capture.calls[0]?.body;
+      expect(cacheCreateReq.model).toBe(
+        `projects/demo-project/locations/global/publishers/google/models/${AxAIGoogleGeminiModel.Gemini25Flash}`
+      );
+    });
+  });
+
   describe('token usage normalization for cached content', () => {
     it('should subtract cachedContentTokenCount from promptTokens', async () => {
       const response = {

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -258,7 +258,7 @@ class AxAIGoogleGeminiImpl
 
   constructor(
     private config: AxAIGoogleGeminiConfig,
-    private isVertex: boolean,
+    private vertexConfig: { projectId: string; region: string } | undefined,
     private endpointId?: string,
     private apiKey?: string | (() => Promise<string>),
     private options?: AxAIGoogleGeminiArgs<any>['options'],
@@ -339,8 +339,44 @@ class AxAIGoogleGeminiImpl
     return this.tokensUsed;
   }
 
+  private get isVertex(): boolean {
+    return this.vertexConfig !== undefined;
+  }
+
   private getVertexApiURL(model: string, beta?: boolean): string | undefined {
     return this.isVertex ? this.vertexApiURLForModel?.(model, beta) : undefined;
+  }
+
+  /**
+   * Resolve the Vertex `cachedContents` resource context. Vertex caches live
+   * at `/projects/{p}/locations/{r}/cachedContents` (no `publishers/google`
+   * segment, unlike chat URLs).
+   *
+   * @see https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-create#location_support.
+   *
+   * Returns `undefined` for non-Vertex providers.
+   */
+  private getVertexCacheContext():
+    | {
+        baseUrl: string;
+        parent: string;
+        modelResource: (model: string) => string;
+      }
+    | undefined {
+    if (!this.vertexConfig) return undefined;
+    const { projectId, region } = this.vertexConfig;
+    // The global endpoint requires `v1beta1` for `cachedContents`; regional
+    // endpoints work on the stable `v1`.
+    const baseUrl =
+      region === 'global'
+        ? 'https://aiplatform.googleapis.com/v1beta1'
+        : `https://${region}-aiplatform.googleapis.com/v1`;
+    const parent = `projects/${projectId}/locations/${region}`;
+    return {
+      baseUrl,
+      parent,
+      modelResource: (model) => `${parent}/publishers/google/models/${model}`,
+    };
   }
 
   getModelConfig(): AxModelConfig {
@@ -1300,10 +1336,10 @@ class AxAIGoogleGeminiImpl
     ) {
       return undefined;
     }
-
     // Build the cache creation request
+    const vertexCtx = this.getVertexCacheContext();
     const cacheRequest: AxAIGoogleGeminiCacheCreateRequest = {
-      model: this.isVertex ? model : `models/${model}`,
+      model: vertexCtx ? vertexCtx.modelResource(model) : `models/${model}`,
       ttl: `${ttlSeconds}s`,
       displayName: `ax-cache-${Date.now()}`,
     };
@@ -1327,23 +1363,20 @@ class AxAIGoogleGeminiImpl
 
     // Build API endpoint
     let apiPath: string;
-    if (this.isVertex) {
-      apiPath = '/cachedContents';
+    if (vertexCtx) {
+      apiPath = `/${vertexCtx.parent}/cachedContents`;
     } else {
-      apiPath = '/cachedContents';
       // Add API key for non-Vertex
       const keyValue =
         typeof this.apiKey === 'function' ? 'ASYNC_KEY' : this.apiKey;
-      apiPath += `?key=${keyValue}`;
+      apiPath = `/cachedContents?key=${keyValue}`;
     }
 
     return {
       type: 'create',
       apiConfig: {
         name: apiPath,
-        ...(this.isVertex
-          ? { url: this.getVertexApiURL(model as string, options?.beta) }
-          : {}),
+        ...(vertexCtx ? { url: vertexCtx.baseUrl } : {}),
       },
       request: cacheRequest,
       parseResponse: (response: unknown): AxContextCacheInfo | undefined => {
@@ -1407,9 +1440,7 @@ class AxAIGoogleGeminiImpl
    */
   buildCacheUpdateTTLOp = (
     cacheName: string,
-    ttlSeconds: number,
-    model?: AxAIGoogleGeminiModel,
-    beta?: AxAIServiceOptions['beta']
+    ttlSeconds: number
   ): AxContextCacheOperation => {
     const updateRequest: AxAIGoogleGeminiCacheUpdateRequest = {
       ttl: `${ttlSeconds}s`,
@@ -1423,14 +1454,13 @@ class AxAIGoogleGeminiImpl
       apiPath += `?key=${keyValue}`;
     }
 
+    const vertexCtx = this.getVertexCacheContext();
     return {
       type: 'update',
       apiConfig: {
         name: apiPath,
         headers: { 'Content-Type': 'application/json' },
-        ...(this.isVertex && model
-          ? { url: this.getVertexApiURL(model, beta) }
-          : {}),
+        ...(vertexCtx ? { url: vertexCtx.baseUrl } : {}),
       },
       request: updateRequest,
       parseResponse: (response: unknown): AxContextCacheInfo | undefined => {
@@ -1456,11 +1486,13 @@ class AxAIGoogleGeminiImpl
       apiPath += `?key=${keyValue}`;
     }
 
+    const vertexCtx = this.getVertexCacheContext();
     return {
       type: 'delete',
       apiConfig: {
         name: apiPath,
         headers: { 'Content-Type': 'application/json' },
+        ...(vertexCtx ? { url: vertexCtx.baseUrl } : {}),
       },
       request: {},
       parseResponse: (): undefined => undefined,
@@ -1911,7 +1943,11 @@ export class AxAIGoogleGemini<TModelKey = string> extends AxBaseAI<
     models,
     modelInfo,
   }: Readonly<Omit<AxAIGoogleGeminiArgs<TModelKey>, 'name'>>) {
-    const isVertex = projectId !== undefined && region !== undefined;
+    const vertexConfig =
+      projectId !== undefined && region !== undefined
+        ? { projectId, region }
+        : undefined;
+    const isVertex = vertexConfig !== undefined;
     const Config = {
       ...axAIGoogleGeminiDefaultConfig(),
       ...config,
@@ -1957,7 +1993,7 @@ export class AxAIGoogleGemini<TModelKey = string> extends AxBaseAI<
 
     const aiImpl = new AxAIGoogleGeminiImpl(
       Config,
-      isVertex,
+      vertexConfig,
       endpointId,
       apiKey,
       options,

--- a/src/ax/ai/google-gemini/api.ts
+++ b/src/ax/ai/google-gemini/api.ts
@@ -365,12 +365,11 @@ class AxAIGoogleGeminiImpl
     | undefined {
     if (!this.vertexConfig) return undefined;
     const { projectId, region } = this.vertexConfig;
-    // The global endpoint requires `v1beta1` for `cachedContents`; regional
-    // endpoints work on the stable `v1`.
-    const baseUrl =
+    const host =
       region === 'global'
-        ? 'https://aiplatform.googleapis.com/v1beta1'
-        : `https://${region}-aiplatform.googleapis.com/v1`;
+        ? 'aiplatform.googleapis.com'
+        : `${region}-aiplatform.googleapis.com`;
+    const baseUrl = `https://${host}/v1`;
     const parent = `projects/${projectId}/locations/${region}`;
     return {
       baseUrl,

--- a/src/ax/ai/types.ts
+++ b/src/ax/ai/types.ts
@@ -1061,9 +1061,7 @@ export interface AxAIServiceImpl<
    */
   buildCacheUpdateTTLOp?(
     cacheName: string,
-    ttlSeconds: number,
-    model?: TModel,
-    beta?: AxAIServiceOptions['beta']
+    ttlSeconds: number
   ): AxContextCacheOperation;
 
   /**


### PR DESCRIPTION
## Summary

Fixes two bugs that made explicit context caching silently no-op on Vertex (`projectId` + `region`):

- **Wrong URL**: cache create POSTs were composed via the chat-URL builder, yielding `…/publishers/google/cachedContents` → `404 <!DOCTYPE html>`. `executeCacheOperation` swallows the error, so `registry.set` never fires and callers see no `cacheReadTokens` from explicit caching (implicit caching can mask this).
- **Wrong model field**: the cache create body sent the bare model id (`gemini-2.5-flash`), which Vertex rejects: `400 INVALID_ARGUMENT — The Model name … is malformed and it should be in form of projects/{project}/locations/{location}/publishers/google/models/{model}`.

## Fix

- Thread `{projectId, region}` into `AxAIGoogleGeminiImpl` (replacing the `isVertex: boolean` flag) so cache ops can build URLs without the chat-URL builder.
- Add a single `getVertexCacheContext()` helper used by `buildCacheCreateOp`, `buildCacheUpdateTTLOp`, and `buildCacheDeleteOp`:
  - Regional → `https://{region}-aiplatform.googleapis.com/v1`
  - `global` → `https://aiplatform.googleapis.com/v1` (no region prefix)
  - Create path: `/projects/{p}/locations/{r}/cachedContents` (no `/publishers/google` segment, unlike chat URLs).
  - Update/delete reuse the full `cacheName` Vertex returns.
  - The `model` field in the create body is the full `projects/{p}/locations/{r}/publishers/google/models/{m}` resource path.
- `buildCacheCreateOp` returns `undefined` when project/region is missing rather than POST a known-bad URL; chat and implicit caching are unaffected.
- The `delete` op previously set no `apiConfig.url` and fell through to `this.apiURL` (the chat URL) — same family of bug — and is implicitly fixed by the shared helper.

The chat path itself is unchanged; `prepareCachedChatReq` still goes through `vertexApiURLForModel` (correct for chat) and references the cache by name in the request body.

## Breaking change

`AxAIServiceImpl.buildCacheUpdateTTLOp` loses its optional `model` and `beta` params. The interface is exported, so any external implementer will need to drop those args.

## Pre-existing issues this PR does NOT resolve

- **Cross-region cache-key collision**: `ContextCacheKey` in `base.ts` is `(providerName, model, contentHash)` — region/project are not included, but Vertex `cachedContents` are location-scoped. Two `AxAIGoogleGemini` instances sharing a registry (e.g. Redis) across regions will pull each other's `cacheName` and pass it to a different-region `generateContent`, which fails. This was masked before because the create call always 404'd; now that explicit caching actually writes to the registry, it's reachable. Worth a follow-up to include `projectId`/`region` in the cache key on Vertex.
- **`'ASYNC_KEY'` literal in non-Vertex URL**: when `apiKey` is a function, `?key=ASYNC_KEY` is concatenated into the URL literally (see `buildCacheCreateOp` / `buildCacheUpdateTTLOp` / `buildCacheDeleteOp`). Pre-existing; surfaced again by this refactor.
- **`displayName: ax-cache-${Date.now()}`**: same-millisecond collision risk. Pre-existing.

## Test plan

- [x] New tests assert regional Vertex cache creation routes to `https://us-central1-aiplatform.googleapis.com/v1/projects/{p}/locations/{r}/cachedContents` with the full `model` resource path
- [x] New tests assert global Vertex cache creation routes to `https://aiplatform.googleapis.com/v1/...` with no region prefix
- [x] Verified end-to-end against `gemini-2.5-flash` with a 3.6k-token system prompt on `us-central1` and `global`: first call creates the cache (`promptTokens` falls from ~3457 to ~7, `cacheReadTokens=3446`), subsequent calls reuse via `useCacheByName`, registry entry written exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)